### PR TITLE
[Footer] Mis à jour de l'UI pour les liens internes

### DIFF
--- a/site/src/app/components/pass-sport-footer/PassSportFooter.tsx
+++ b/site/src/app/components/pass-sport-footer/PassSportFooter.tsx
@@ -87,23 +87,23 @@ export default function PassSportFooter() {
       links: [
         {
           text: 'Accueil',
-          linkProps: { href: '#', target: '_blank' },
+          linkProps: { href: '#' },
         },
         {
           text: `Qu'est-ce que le Pass'Sport`,
-          linkProps: { href: '#', target: '_blank' },
+          linkProps: { href: '#' },
         },
         {
           text: 'Trouver un club',
-          linkProps: { href: '/v2/trouver-un-club', target: '_blank' },
+          linkProps: { href: '/v2/trouver-un-club' },
         },
         {
           text: 'Une question ?',
-          linkProps: { href: '/v2/une-question', target: '_blank' },
+          linkProps: { href: '/v2/une-question' },
         },
         {
           text: 'Espace presse',
-          linkProps: { href: '#', target: '_blank' },
+          linkProps: { href: '#' },
         },
       ],
     },


### PR DESCRIPTION
### Description
Petite PR suite à un feedback de Perrine sur le footer

- Pas de liens ouvrant une nouvelle fenêtre pour les liens internes 

<img width="567" alt="Screenshot 2024-04-22 at 10 15 46" src="https://github.com/betagouv/pass-sport/assets/1215376/aa1f084e-2b2b-47b9-aeb4-1d365db25a9f">
