### PR TITLE
[Frontend] Breadcrumb UI fix found in club page

### DIFF
--- a/site/src/app/components/pass-sport-breadcrumb/styles.module.scss
+++ b/site/src/app/components/pass-sport-breadcrumb/styles.module.scss
@@ -9,14 +9,10 @@
     padding-right: 1rem;
   }
 
-  div {
-    margin: auto;
+  div,
+  nav {
     max-width: $layout-max-width;
+    margin: auto;
     background-color: #ececfe;
-
-    nav {
-      margin: auto;
-      background-color: #ececfe;
-    }
   }
 }


### PR DESCRIPTION
### Description
⬆️ 

### Before
<img width="1728" alt="Screenshot 2024-04-22 at 15 30 17" src="https://github.com/betagouv/pass-sport/assets/1215376/76c2a5fe-a654-4241-85e8-585decfb1a52">


### AFter
<img width="1728" alt="Screenshot 2024-04-22 at 15 30 06" src="https://github.com/betagouv/pass-sport/assets/1215376/cd229e2c-bfd1-4c22-b4da-938796c184d2">
