### PR TITLE
[Frontend] Thème clair seulement autorisé

### DIFF
--- a/site/src/app/defaultColorScheme.ts
+++ b/site/src/app/defaultColorScheme.ts
@@ -1,3 +1,3 @@
 import type { DefaultColorScheme } from '@codegouvfr/react-dsfr/next-appdir';
 
-export const defaultColorScheme: DefaultColorScheme = 'system';
+export const defaultColorScheme: DefaultColorScheme = 'light';


### PR DESCRIPTION
### Description
Autorisation du thème clair seulement

Le thème est sauvegardé dans le localStorage, il suffirait donc de le clear pour le cas de Benoit Champy
Source: https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/parametre-d-affichage/