### PR TITLE
[Frontend] "Données personnelles" + "Mentions légales" pages

### DIFF
--- a/site/components/PageHeader/PageHeader.tsx
+++ b/site/components/PageHeader/PageHeader.tsx
@@ -1,13 +1,17 @@
 import styles from './styles.module.scss';
+import cn from 'classnames';
 
 interface IProps {
   title: string;
   subtitle?: string;
+  classes?: {
+    container?: string;
+  };
 }
 
-export default function PageHeader({ title, subtitle }: IProps) {
+export default function PageHeader({ title, subtitle, classes }: IProps) {
   return (
-    <div className={styles.container}>
+    <div className={cn(styles.container, classes?.container)}>
       <div className={styles.titlewrapper}>
         <h1 className={styles.title}>{title}</h1>
         {subtitle && <p className={styles.subtitle}>{subtitle}</p>}

--- a/site/components/PageHeader/PageHeader.tsx
+++ b/site/components/PageHeader/PageHeader.tsx
@@ -11,11 +11,11 @@ interface IProps {
 
 export default function PageHeader({ title, subtitle, classes }: IProps) {
   return (
-    <div className={cn(styles.container, classes?.container)}>
+    <header className={cn(styles.container, classes?.container)}>
       <div className={styles.titlewrapper}>
         <h1 className={styles.title}>{title}</h1>
         {subtitle && <p className={styles.subtitle}>{subtitle}</p>}
       </div>
-    </div>
+    </header>
   );
 }

--- a/site/src/app/components/pass-sport-breadcrumb/PassSportBreadcrumb.tsx
+++ b/site/src/app/components/pass-sport-breadcrumb/PassSportBreadcrumb.tsx
@@ -10,6 +10,7 @@ export const NAVIGATION_ITEM_MAP: { [key: string]: string } = {
   '/v2/tout-savoir-sur-le-pass-sport': 'Tout savoir sur le pass Sport',
   '/v2/trouver-un-club': 'Trouver un club partenaire',
   '/v2/politique-de-confidentialite': 'Politique de confidentialité',
+  '/v2/mentions-legales': 'Mentions légales',
 };
 
 export default function PassSportBreadcrumb() {

--- a/site/src/app/components/pass-sport-breadcrumb/PassSportBreadcrumb.tsx
+++ b/site/src/app/components/pass-sport-breadcrumb/PassSportBreadcrumb.tsx
@@ -9,6 +9,7 @@ export const NAVIGATION_ITEM_MAP: { [key: string]: string } = {
   '/v2/une-question': 'Une question ?',
   '/v2/tout-savoir-sur-le-pass-sport': 'Tout savoir sur le pass Sport',
   '/v2/trouver-un-club': 'Trouver un club partenaire',
+  '/v2/politique-de-confidentialite': 'Politique de confidentialité',
 };
 
 export default function PassSportBreadcrumb() {

--- a/site/src/app/components/pass-sport-footer/PassSportFooter.tsx
+++ b/site/src/app/components/pass-sport-footer/PassSportFooter.tsx
@@ -54,7 +54,7 @@ export default function PassSportFooter() {
     {
       text: 'Mentions légales',
       linkProps: {
-        href: '#',
+        href: '/v2/mentions-legales',
       },
     },
     {

--- a/site/src/app/components/pass-sport-footer/PassSportFooter.tsx
+++ b/site/src/app/components/pass-sport-footer/PassSportFooter.tsx
@@ -60,7 +60,7 @@ export default function PassSportFooter() {
     {
       text: 'Données personnelles',
       linkProps: {
-        href: '#',
+        href: '/v2/politique-de-confidentialite',
       },
     },
     {

--- a/site/src/app/v2/mentions-legales/page.tsx
+++ b/site/src/app/v2/mentions-legales/page.tsx
@@ -13,7 +13,7 @@ export default function PolitiqueDeConfidentialite() {
           container: styles['page-header'],
         }}
       />
-      <div className={styles.wrapper}>
+      <main className={styles.wrapper}>
         <section className="fr-mb-6w">
           <p className="fr-mb-2w">
             Le Portail pass Sport est un service du ministère des Sports et des Jeux Olympiques et
@@ -120,7 +120,7 @@ export default function PolitiqueDeConfidentialite() {
             purement technique, nécessaire à la production de statistiques de consultations.
           </p>
         </section>
-      </div>
+      </main>
 
       <EligibilityTestBanner />
       <SocialMediaPanel />

--- a/site/src/app/v2/mentions-legales/page.tsx
+++ b/site/src/app/v2/mentions-legales/page.tsx
@@ -1,0 +1,129 @@
+import SocialMediaPanel from '@/app/components/social-media-panel/SocialMediaPanel';
+import PageHeader from '../../../../components/PageHeader/PageHeader';
+import styles from './style.module.scss';
+import EligibilityTestBanner from '@/components/eligibility-test-banner/EligibilityTestBanner';
+
+export default function PolitiqueDeConfidentialite() {
+  return (
+    <div>
+      <PageHeader
+        title="Mentions légales"
+        subtitle=""
+        classes={{
+          container: styles['page-header'],
+        }}
+      />
+      <div className={styles.wrapper}>
+        <section className="fr-mb-6w">
+          <p className="fr-mb-2w">
+            Le Portail pass Sport est un service du ministère des Sports et des Jeux Olympiques et
+            Paralympiques, géré par la direction des sports. Ce service en ligne vise à permettre
+            aux bénéficiaires du dispositif pass Sport de vérifier leur éligibilité et le cas
+            échéant par la télé déclaration des informations nécessaires à obtenir le code
+            alphanumérique individuel à présenter au club sportif lors de leur inscription. Ce
+            service en ligne vise également à permettre à la direction des sports de délivrer toutes
+            les informations et actualités relatives aux bénéficiaires leurs pass Sport.
+          </p>
+
+          <p className="fr-mb-2w">
+            Les données renseignées par les bénéficiaires dans ce portail ne sont accessibles
+            qu&apos;aux services de l&apos;Etat français chargés d&apos;instruire les demandes.
+            L&apos;utilisation de ce service doit faciliter la délivrance du dispositif pass Sport.
+          </p>
+
+          <p className="fr-mb-2w">
+            Les informations recueillies font l&apos;objet d&apos;un traitement informatique destiné
+            à vérifier les conditions d&apos;obtention du pass Sport. Ces informations sont
+            susceptibles d&apos;être communiquées aux services de l&apos;Etat et organismes définis
+            aux articles 7 et 8 du décret modifié relatif au « pass Sport ».
+          </p>
+
+          <p className="fr-mb-2w">
+            Sur le fondement de l&apos;article 6.1.e du Règlement (UE) 2016/679 du Parlement
+            européen et du Conseil du 27 avril 2016 relatif à la protection des personnes physiques
+            à l&apos;égard du traitement des données à caractère personnel et à la libre circulation
+            de ces données (règlement général sur la protection des données, ou RGPD) et en
+            application de l&apos;article 32 de la loi du 6 janvier 1978 modifiée, les personnes
+            bénéficient d&apos;un droit d&apos;accès et de rectification aux informations les
+            concernant, sur simple demande à :
+          </p>
+
+          <p className="fr-mb-2w">
+            Ministère des Sports et des Jeux Olympiques et Paralympiques - Sous-direction du
+            pilotage et de l&apos;évolution des politiques publiques du sport - DS.1A
+          </p>
+
+          <p className="fr-mb-2w">
+            95 avenue de France <br />
+            75 650 Paris CEDEX 13 <br />
+            Tél : 01 40 45 90 00 <br />
+          </p>
+
+          <p>Responsable de publication : Fabienne BOURDAIS, Directrice des sports</p>
+
+          <p>
+            Administrateur du portail : Jean-François HATTE - Sous-direction du pilotage et de
+            l&apos;évolution des politiques publiques du sport - DS.1. Contact :
+            passsport@sports.gouv.fr
+          </p>
+        </section>
+
+        <section className="fr-mb-6w">
+          <h4 className="fr-mb-2w">Accès au site</h4>
+
+          <p>
+            Les utilisateurs du site web sont tenus de respecter les dispositions de la loi du 6
+            janvier 1978 relative à l&apos;informatique, aux fichiers et aux libertés, dont la
+            violation est passible de sanctions pénales. Ils doivent notamment s&apos;abstenir,
+            d&apos;une manière générale, de porter atteinte à la vie privée ou à la réputation des
+            personnes.
+          </p>
+        </section>
+
+        <section className="fr-mb-6w">
+          <h4 className="fr-mb-2w">Contenu du site</h4>
+
+          <p className="fr-mb-2w">
+            Le ministère des Sports et des Jeux Olympiques et Paralympiques met à disposition des
+            utilisateurs de ce site web des informations et outils disponibles et vérifiés.
+          </p>
+
+          <p>
+            Il s&apos;efforcera de corriger autant que faire se peut les erreurs ou omissions qui
+            lui seront signalées par les utilisateurs (en contactant l&apos;administrateur du
+            portail).
+          </p>
+        </section>
+
+        <section className="fr-mb-6w">
+          <h4 className="fr-mb-2w">Propriété</h4>
+
+          <p>
+            La structure générale, ainsi que les logiciels, textes, images animées ou fixes, sons,
+            savoir-faire, dessins, graphismes et tous autres éléments composant ce site web sont de
+            l&apos;utilisation exclusive du ministère chargé des sports. Les contenus ne sauraient
+            être reproduits librement sans demande préalable et sans l&apos;indication de la source.
+            Les demandes d&apos;autorisation de reproduction d&apos;un contenu doivent être
+            adressées à la rédaction du site (en contactant l&apos;administrateur du portail). La
+            demande devra préciser le contenu visé ainsi que le site sur lequel ce dernier figurera.
+            En outre, les informations utilisées ne doivent l&apos;être qu&apos;à des fins
+            associatives ou professionnelles, toute diffusion ou utilisation à des fins commerciales
+            ou publicitaires étant exclues.
+          </p>
+        </section>
+
+        <section className="fr-mb-6w">
+          <h4 className="fr-mb-2w">Données personnelles</h4>
+
+          <p>
+            Ce site ne collecte aucune autre donnée que des adresses IP destinées à un usage
+            purement technique, nécessaire à la production de statistiques de consultations.
+          </p>
+        </section>
+      </div>
+
+      <EligibilityTestBanner />
+      <SocialMediaPanel />
+    </div>
+  );
+}

--- a/site/src/app/v2/mentions-legales/style.module.scss
+++ b/site/src/app/v2/mentions-legales/style.module.scss
@@ -1,0 +1,19 @@
+@import '../../sassVariables.module';
+
+.wrapper {
+  max-width: $max-width;
+  margin: auto;
+  margin-top: 50px;
+  margin-bottom: 80px;
+  padding: 0 2rem;
+
+  @media screen and (max-width: $lg) {
+    padding: 0 1rem;
+  }
+}
+
+// Raise the specificity by adding twice the classname
+.page-header.page-header {
+  height: auto;
+  padding-bottom: 2rem;
+}

--- a/site/src/app/v2/politique-de-confidentialite/page.tsx
+++ b/site/src/app/v2/politique-de-confidentialite/page.tsx
@@ -14,7 +14,7 @@ export default function PolitiqueDeConfidentialite() {
           container: styles['page-header'],
         }}
       />
-      <div className={styles.wrapper}>
+      <main className={styles.wrapper}>
         <section className="fr-mb-6w">
           <h4 className="fr-mb-2w">Article 1 - Définitions</h4>
           <p className="fr-mb-2w">
@@ -292,7 +292,7 @@ export default function PolitiqueDeConfidentialite() {
             l&apos;incident en question.
           </p>
         </section>
-      </div>
+      </main>
 
       <EligibilityTestBanner />
       <SocialMediaPanel />

--- a/site/src/app/v2/politique-de-confidentialite/page.tsx
+++ b/site/src/app/v2/politique-de-confidentialite/page.tsx
@@ -32,14 +32,14 @@ export default function PolitiqueDeConfidentialite() {
           </p>
           <p className="fr-mb-2w">
             <span className="fr-text--bold">« Traitement »</span> : toute opération ou tout ensemble
-            d'opérations effectués ou non à l'aide de procédés automatisés et appliqués à des
-            données ou des ensembles de données à caractère personnel (ex : collecte,
+            d&apos;opérations effectués ou non à l&apos;aide de procédés automatisés et appliqués à
+            des données ou des ensembles de données à caractère personnel (ex : collecte,
             enregistrement, conservation, extraction, utilisation, etc.).
           </p>
           <p className="fr-mb-2w">
             <span className="fr-text--bold">« Responsable de traitement »</span> : personne physique
             ou morale, autorité publique, service ou autre organisme qui, seul ou conjointement avec
-            d'autres, détermine les finalités et les moyens du traitement.
+            d&apos;autres, détermine les finalités et les moyens du traitement.
           </p>
         </section>
 
@@ -108,7 +108,7 @@ export default function PolitiqueDeConfidentialite() {
             (règlement général sur la protection des données - RGPD) relatif à l&apos;exécution
             d&apos;une mission d&apos;intérêt public dont est investie la Direction des sports au
             sens des articles L. 100-1 et L. 100-2 du code du sport et du décret n° 2023-741 du 8
-            août 2023 relatif au « Pass'Sport » 2023.
+            août 2023 relatif au « Pass&apos;Sport » 2023.
           </p>
         </section>
 
@@ -119,19 +119,19 @@ export default function PolitiqueDeConfidentialite() {
           <p>Pour les bénéficiaires éligibles au dispositif pass Sport</p>
           <ul className="fr-pl-4w">
             <li>
-              Données relatives à l'identité de l'allocataire (responsable légal du bénéficiaire) :
-              civilité, nom, prénom, lieu de naissance ;
+              Données relatives à l&apos;identité de l&apos;allocataire (responsable légal du
+              bénéficiaire) : civilité, nom, prénom, lieu de naissance ;
             </li>
             <li>
-              Données relatives à l'identité de bénéficiaire : nom, prénom, sexe, date de naissance
-              ;
+              Données relatives à l&apos;identité de bénéficiaire : nom, prénom, sexe, date de
+              naissance ;
             </li>
             <li>Coordonnées : adresse postale, courriel, téléphone.</li>
           </ul>
 
           <p>Pour les exploitants de structures éligibles au dispositif pass Sport</p>
           <ul className="fr-pl-4w">
-            <li>Données relatives à l'identité : civilité, nom, prénom ;</li>
+            <li>Données relatives à l&apos;identité : civilité, nom, prénom ;</li>
             <li>Coordonnées : courriel, téléphone ;</li>
             <li>Données relatives à la vie professionnelle : fonction dans la structure.</li>
           </ul>
@@ -219,7 +219,7 @@ export default function PolitiqueDeConfidentialite() {
           <p className="fr-mb-2w">Par voie postale à l&apos;adresse suivante :</p>
 
           <p className={cn(styles['wrapper__text--center'], 'fr-mb-2w')}>
-            Ministère de l'éducation nationale et de la jeunesse <br />
+            Ministère de l&apos;éducation nationale et de la jeunesse <br />
             Délégué à la protection des données(DPD) <br />
             110, rue de Grenelle <br />
             75357 Paris Cedex 07
@@ -262,34 +262,34 @@ export default function PolitiqueDeConfidentialite() {
             La Direction des sports s&apos;engage à mettre en œuvre toutes les mesures techniques et
             organisationnelles appropriées grâce à des moyens de sécurisation physiques et
             logistiques permettant de garantir un niveau de sécurité adapté au regard des risques
-            d'accès accidentels, non autorisés ou illégaux, de divulgation, d'altération, de perte
-            ou encore de destruction des données personnelles vous concernant, au sens de
+            d&apos;accès accidentels, non autorisés ou illégaux, de divulgation, d&apos;altération,
+            de perte ou encore de destruction des données personnelles vous concernant, au sens de
             l&apos;article 121 de la Loi informatiques et Libertés de 1978 modifiée.
           </p>
 
           <p>
-            Dans l'éventualité où la Direction des sports prendrait connaissance d'un accès illégal
-            aux données personnelles vous concernant, stockées sur nos serveurs ou ceux de nos
-            prestataires, ou d'un accès non autorisé ayant pour conséquence la réalisation des
-            risques identifiés ci-dessus, elle s&apos;engage à :
+            Dans l&apos;éventualité où la Direction des sports prendrait connaissance d&apos;un
+            accès illégal aux données personnelles vous concernant, stockées sur nos serveurs ou
+            ceux de nos prestataires, ou d&apos;un accès non autorisé ayant pour conséquence la
+            réalisation des risques identifiés ci-dessus, elle s&apos;engage à :
           </p>
 
           <ul className="fr-pl-4w">
             <li>
-              Vous notifier l'incident et en informer la CNIL dans les plus brefs délais, si cela
-              est susceptible d'engendrer un risque élevé pour vos droits et libertés ;
+              Vous notifier l&apos;incident et en informer la CNIL dans les plus brefs délais, si
+              cela est susceptible d&apos;engendrer un risque élevé pour vos droits et libertés ;
             </li>
-            <li>Examiner les causes de l'incident ;</li>
+            <li>Examiner les causes de l&apos;incident ;</li>
             <li>
-              Prendre les mesures nécessaires dans la limite du raisonnable afin d'amoindrir les
-              effets négatifs et préjudices pouvant résulter dudit incident.
+              Prendre les mesures nécessaires dans la limite du raisonnable afin d&apos;amoindrir
+              les effets négatifs et préjudices pouvant résulter dudit incident.
             </li>
           </ul>
 
           <p>
             En aucun cas les engagements définis au point ci-dessus ne peuvent être assimilés à une
             quelconque reconnaissance de faute ou de responsabilité quant à la survenance de
-            l'incident en question.
+            l&apos;incident en question.
           </p>
         </section>
       </div>

--- a/site/src/app/v2/politique-de-confidentialite/page.tsx
+++ b/site/src/app/v2/politique-de-confidentialite/page.tsx
@@ -1,0 +1,33 @@
+import SocialMediaPanel from '@/app/components/social-media-panel/SocialMediaPanel';
+import PageHeader from '../../../../components/PageHeader/PageHeader';
+import styles from './style.module.scss';
+import EligibilityTestBanner from '@/components/eligibility-test-banner/EligibilityTestBanner';
+
+export default function PolitiqueDeConfidentialite() {
+  return (
+    <div>
+      <PageHeader
+        title="Politique de confidentialité"
+        subtitle="Le ministère des Sports et des Jeux Olympiques et Paralympiques s'engage à ce que la collecte et le traitement de vos données, effectués à partir du portail Pass'Sport, soient conformes au règlement général sur la protection des données (RGPD) et à la loi Informatique et Libertés."
+        classes={{
+          container: styles['page-header'],
+        }}
+      />
+      <div className={styles.wrapper}>
+        <h4 className="fr-mb-2w">À qui sont destinées vos données ?</h4>
+        <p>
+          Le ministère des Sports et des Jeux Olympiques et Paralympiques , situé au 95 avenue de
+          France est responsable du traitement des données personnelles pour le portail
+          Pass&apos;Sport. Sauf mention contraire, les données personnelles qui y sont collectées
+          sont destinées à un usage interne et n&apos;ont pas vocation à être partagées avec des
+          tiers en dehors des cas prévus par les lois et règlements. Elles peuvent néanmoins être
+          rendues accessibles aux prestataires (sous-traitants au sens de la règlementation) du
+          ministère des Sports et des Jeux Olympiques et Paralympiques sous son contrôle, pour les
+          stricts besoins et dans les limites de leur mission.
+        </p>
+      </div>
+      <EligibilityTestBanner />
+      <SocialMediaPanel />
+    </div>
+  );
+}

--- a/site/src/app/v2/politique-de-confidentialite/page.tsx
+++ b/site/src/app/v2/politique-de-confidentialite/page.tsx
@@ -2,30 +2,298 @@ import SocialMediaPanel from '@/app/components/social-media-panel/SocialMediaPan
 import PageHeader from '../../../../components/PageHeader/PageHeader';
 import styles from './style.module.scss';
 import EligibilityTestBanner from '@/components/eligibility-test-banner/EligibilityTestBanner';
+import cn from 'classnames';
 
 export default function PolitiqueDeConfidentialite() {
   return (
     <div>
       <PageHeader
         title="Politique de confidentialité"
-        subtitle="Le ministère des Sports et des Jeux Olympiques et Paralympiques s'engage à ce que la collecte et le traitement de vos données, effectués à partir du portail Pass'Sport, soient conformes au règlement général sur la protection des données (RGPD) et à la loi Informatique et Libertés."
+        subtitle="Politique de confidentialité relative au traitement de données personnelles réalisé dans le cadre de la délivrance du pass Sport 2024"
         classes={{
           container: styles['page-header'],
         }}
       />
       <div className={styles.wrapper}>
-        <h4 className="fr-mb-2w">À qui sont destinées vos données ?</h4>
-        <p>
-          Le ministère des Sports et des Jeux Olympiques et Paralympiques , situé au 95 avenue de
-          France est responsable du traitement des données personnelles pour le portail
-          Pass&apos;Sport. Sauf mention contraire, les données personnelles qui y sont collectées
-          sont destinées à un usage interne et n&apos;ont pas vocation à être partagées avec des
-          tiers en dehors des cas prévus par les lois et règlements. Elles peuvent néanmoins être
-          rendues accessibles aux prestataires (sous-traitants au sens de la règlementation) du
-          ministère des Sports et des Jeux Olympiques et Paralympiques sous son contrôle, pour les
-          stricts besoins et dans les limites de leur mission.
-        </p>
+        <section className="fr-mb-6w">
+          <h4 className="fr-mb-2w">Article 1 - Définitions</h4>
+          <p className="fr-mb-2w">
+            Les définitions fournies à l&apos;article 4 du RGPD sont applicables aux présentes.
+          </p>
+          <p className="fr-mb-2w">
+            <span className="fr-text--bold">« Données à caractère personnel »</span> ou{' '}
+            <span className="fr-text--bold">« données personnelles »</span> : toute information se
+            rapportant à une personne physique identifiée ou identifiable. La personne physique peut
+            être identifiée directement ou indirectement.
+          </p>
+          <p className="fr-mb-2w">
+            <span className="fr-text--bold">« Personne concernée »</span> : la personne concernée
+            est la personne physique dont les données personnelles font l&apos;objet du traitement.
+          </p>
+          <p className="fr-mb-2w">
+            <span className="fr-text--bold">« Traitement »</span> : toute opération ou tout ensemble
+            d'opérations effectués ou non à l'aide de procédés automatisés et appliqués à des
+            données ou des ensembles de données à caractère personnel (ex : collecte,
+            enregistrement, conservation, extraction, utilisation, etc.).
+          </p>
+          <p className="fr-mb-2w">
+            <span className="fr-text--bold">« Responsable de traitement »</span> : personne physique
+            ou morale, autorité publique, service ou autre organisme qui, seul ou conjointement avec
+            d'autres, détermine les finalités et les moyens du traitement.
+          </p>
+        </section>
+
+        <section className="fr-mb-6w">
+          <h4 className="fr-mb-2w">Article 2 - Responsable de traitement</h4>
+          <p className="fr-mb-2w">
+            La Direction des sports du ministère des sports et des jeux olympiques et paralympiques
+            (ci-après <span className="fr-text--bold">« la Direction des sports »</span>) est le
+            responsable de traitement de vos données personnelles. Elle collecte et traite vos
+            données dans le cadre du traitement de données personnelles opéré pour la délivrance du
+            pass Sport 2024.
+          </p>
+
+          <p className="fr-mb-2w">
+            <span className="fr-text--bold">Adresse postale :</span> <br /> <br />
+            <span className="fr-text--bold">LA DIRECTION DES SPORTS,</span>
+            <br />
+            Située au 95 avenue de France 75013 PARIS
+          </p>
+
+          <p className="fr-mb-2w">
+            <span className="fr-text--bold">Adresse mail :</span>
+            <br />
+            ds-rgpd@sports.gouv.fr
+          </p>
+
+          <p>
+            La Direction des sports s&apos;engage à ce que le traitement de vos données à caractère
+            personnel effectué dans le cadre de l&apos;envoi du pass Sport 2024 respecte la
+            règlementation en vigueur applicable au traitement de données à caractère personnel et,
+            en particulier,{' '}
+            <a
+              href="https://www.cnil.fr/fr/reglement-europeen-protection-donnees"
+              title="Lien vers les dispositions du Règlement (UE) 2016/679 général sur la protection des données"
+              aria-label="Lien vers les dispositions du Règlement (UE) 2016/679 général sur la protection des données"
+              target="_blank"
+            >
+              les dispositions du Règlement (UE) 2016/679 général sur la protection des données
+            </a>{' '}
+            (« RGPD »), de la{' '}
+            <a
+              href="https://www.cnil.fr/fr/la-loi-informatique-et-libertes"
+              title="Lien vers la loi n°78-17 informatique et Libertés du 6 janvier 1978 modifiée"
+              aria-label="Lien vers la loi n°78-17 informatique et Libertés du 6 janvier 1978 modifiée"
+              target="_blank"
+            >
+              loi n°78-17 informatique et Libertés du 6 janvier 1978 modifiée
+            </a>{' '}
+            (« LIL ») et toute règlementation subséquente, ainsi que les dispositions prises par
+            toute autorité de contrôle compétente, notamment en France la Commission Nationale
+            Informatique & Libertés dit “CNIL”.
+          </p>
+        </section>
+
+        <section className="fr-mb-6w">
+          <h4 className="fr-mb-2w">Article 3 - Finalités du traitement des données</h4>
+          <p>Le présent traitement a pour finalités la délivrance du pass Sport 2024.</p>
+        </section>
+
+        <section className="fr-mb-6w">
+          <h4 className="fr-mb-2w">Article 4 - Base légale</h4>
+          {/* ATTENTION: A modifier dès la publication du décret 2024. pour ce texte suivant: "décret n° 2023-741 du 8
+            août 2023 relatif au « Pass'Sport » 2023." */}
+          <p>
+            Le présent traitement se fonde sur l&apos;article 6. 1. e du Règlement européen 2016/679
+            (règlement général sur la protection des données - RGPD) relatif à l&apos;exécution
+            d&apos;une mission d&apos;intérêt public dont est investie la Direction des sports au
+            sens des articles L. 100-1 et L. 100-2 du code du sport et du décret n° 2023-741 du 8
+            août 2023 relatif au « Pass'Sport » 2023.
+          </p>
+        </section>
+
+        <section className="fr-mb-6w">
+          <h4 className="fr-mb-2w">Article 5 - Typologie des données traitées</h4>
+          {/* ATTENTION: A modifier dès la publication du décret 2024. pour ce texte suivant: "décret n° 2023-741 du 8
+            août 2023 relatif au « Pass'Sport » 2023." */}
+          <p>Pour les bénéficiaires éligibles au dispositif pass Sport</p>
+          <ul className="fr-pl-4w">
+            <li>
+              Données relatives à l'identité de l'allocataire (responsable légal du bénéficiaire) :
+              civilité, nom, prénom, lieu de naissance ;
+            </li>
+            <li>
+              Données relatives à l'identité de bénéficiaire : nom, prénom, sexe, date de naissance
+              ;
+            </li>
+            <li>Coordonnées : adresse postale, courriel, téléphone.</li>
+          </ul>
+
+          <p>Pour les exploitants de structures éligibles au dispositif pass Sport</p>
+          <ul className="fr-pl-4w">
+            <li>Données relatives à l'identité : civilité, nom, prénom ;</li>
+            <li>Coordonnées : courriel, téléphone ;</li>
+            <li>Données relatives à la vie professionnelle : fonction dans la structure.</li>
+          </ul>
+        </section>
+
+        <section className="fr-mb-6w">
+          <h4 className="fr-mb-2w">Article 6 - Durée de conservation des données</h4>
+          <p className="fr-mb-2w">
+            Les données à caractère personnel des bénéficiaires éligibles au dispositif pass Sport
+            seront effacées au bout de 12 mois à compter de leur réception par la direction des
+            sports.
+          </p>
+
+          <p>
+            Les données à caractère personnel des exploitants de structures éligibles au dispositif
+            pass Sport seront effacées lorsque ces derniers quitteront leurs fonctions.
+          </p>
+        </section>
+
+        <section className="fr-mb-6w">
+          <h4 className="fr-mb-2w">Article 8 - Personnes concernées</h4>
+          <p className="fr-mb-2w">
+            Sont concernées par le traitement mentionné à l&apos;article 3 les bénéficiaires
+            éligibles au dispositif pass Sport et les exploitants de structures éligibles au
+            dispositif pass Sport.
+          </p>
+        </section>
+
+        <section className="fr-mb-6w">
+          <h4 className="fr-mb-2w">Article 9 - Source des données</h4>
+          <p>
+            Vos données traitées ont été collectées indirectement. Elles nous ont été communiquées
+            par le Centre National des Œuvres Universitaires et Scolaires Établissement public
+            national, La Caisse nationale des allocations familiales et la Caisse Centrale de la
+            Mutualité Sociale Agricole.
+          </p>
+        </section>
+
+        <section className="fr-mb-6w">
+          <h4 className="fr-mb-2w">Article 10 - Nécessité de la collecte</h4>
+          <p className="fr-mb-2w">
+            Seules les données à caractère personnel nécessaires pour le traitement réalisé dans le
+            cadre de la délivrance du pass Sport 2024 seront traitées.
+          </p>
+
+          <p>
+            Le recueil de vos données à caractère personnel est obligatoire pour répondre aux
+            finalités mentionnées à l&apos;article 3.
+          </p>
+        </section>
+
+        <section className="fr-mb-6w">
+          <h4 className="fr-mb-2w">Article 11 - Quels sont vos droits ? Comment les exercer ?</h4>
+          <p className="fr-mb-2w">
+            Conformément à la règlementation applicable, vous disposez d&apos;un droit d&apos;accès,
+            de rectification, d&apos;effacement, de limitation et d&apos;opposition des données qui
+            vous concernent.
+          </p>
+
+          <ul className="fr-pl-4w">
+            <li className="fr-text--bold">Exercice de vos droits</li>
+          </ul>
+
+          <p className="fr-mb-2w">
+            Vous pouvez exercer ces droits en vous adressant aux responsables de traitement : <br />
+            Par voie postale, à l&apos;adresse suivante :
+          </p>
+
+          <p className={cn(styles['wrapper__text--center'], 'fr-mb-2w')}>
+            LA DIRECTION DES SPORTS <br /> 95 avenue de France 75013 PARIS
+          </p>
+
+          <p>Par voie électronique à l&apos;adresse suivante : ds-rgpd@sports.gouv.fr</p>
+
+          <ul className="fr-pl-4w">
+            <li className="fr-text--bold">Délégué à la protection des données</li>
+          </ul>
+
+          <p className="fr-mb-2w">
+            Si vous rencontrez des difficultés dans l&apos;exercice de vos droits, vous pouvez
+            saisir le Délégué à la protection des données du ministère chargé des sports, aux
+            coordonnées suivantes :
+          </p>
+
+          <p className="fr-mb-2w">Par voie postale à l&apos;adresse suivante :</p>
+
+          <p className={cn(styles['wrapper__text--center'], 'fr-mb-2w')}>
+            Ministère de l'éducation nationale et de la jeunesse <br />
+            Délégué à la protection des données(DPD) <br />
+            110, rue de Grenelle <br />
+            75357 Paris Cedex 07
+          </p>
+
+          <p className="fr-mb-2w">
+            Par voie électronique à l&apos;adresse suivante : dpd@education.gouv.fr <br />
+            Ou via le formulaire de saisine en ligne :{' '}
+            <a
+              href="http://www.education.gouv.fr/pid33441/nous-contacter.html#RGPD"
+              title="Lien vers le formulaire de saisine en ligne pour les difficultés rencontrées dans l'exercice de vos droits"
+              aria-label="Lien vers le formulaire de saisine en ligne pour les difficultés rencontrées dans l'exercice de vos droits"
+              target="_blank"
+            >
+              http://www.education.gouv.fr/pid33441/nous-contacter.html#RGPD
+            </a>
+          </p>
+
+          <ul className="fr-pl-4w">
+            <li className="fr-text--bold">Réclamation auprès de la CNIL</li>
+          </ul>
+
+          <p>
+            Si vous estimez après nous avoir contactés que les droits sur vos données n&apos;ont pas
+            été respectés, vous pouvez introduire une réclamation auprès de la CNIL.{' '}
+            <a
+              href="https://www.cnil.fr/fr/mes-demarches/les-droits-pour-maitriser-vos-donnees-personnelles"
+              title="Voir le site de la CNIL pour plus d'informations sur vos droits."
+              aria-label="Voir le site de la CNIL pour plus d'informations sur vos droits."
+              target="_blank"
+            >
+              Voir le site de la CNIL pour plus d&apos;informations sur vos droits.
+            </a>
+          </p>
+        </section>
+
+        <section className="fr-mb-6w">
+          <h4 className="fr-mb-2w">Article 14 - Indications en cas de violation de données</h4>
+          <p className="fr-mb-2w">
+            La Direction des sports s&apos;engage à mettre en œuvre toutes les mesures techniques et
+            organisationnelles appropriées grâce à des moyens de sécurisation physiques et
+            logistiques permettant de garantir un niveau de sécurité adapté au regard des risques
+            d'accès accidentels, non autorisés ou illégaux, de divulgation, d'altération, de perte
+            ou encore de destruction des données personnelles vous concernant, au sens de
+            l&apos;article 121 de la Loi informatiques et Libertés de 1978 modifiée.
+          </p>
+
+          <p>
+            Dans l'éventualité où la Direction des sports prendrait connaissance d'un accès illégal
+            aux données personnelles vous concernant, stockées sur nos serveurs ou ceux de nos
+            prestataires, ou d'un accès non autorisé ayant pour conséquence la réalisation des
+            risques identifiés ci-dessus, elle s&apos;engage à :
+          </p>
+
+          <ul className="fr-pl-4w">
+            <li>
+              Vous notifier l'incident et en informer la CNIL dans les plus brefs délais, si cela
+              est susceptible d'engendrer un risque élevé pour vos droits et libertés ;
+            </li>
+            <li>Examiner les causes de l'incident ;</li>
+            <li>
+              Prendre les mesures nécessaires dans la limite du raisonnable afin d'amoindrir les
+              effets négatifs et préjudices pouvant résulter dudit incident.
+            </li>
+          </ul>
+
+          <p>
+            En aucun cas les engagements définis au point ci-dessus ne peuvent être assimilés à une
+            quelconque reconnaissance de faute ou de responsabilité quant à la survenance de
+            l'incident en question.
+          </p>
+        </section>
       </div>
+
       <EligibilityTestBanner />
       <SocialMediaPanel />
     </div>

--- a/site/src/app/v2/politique-de-confidentialite/page.tsx
+++ b/site/src/app/v2/politique-de-confidentialite/page.tsx
@@ -152,7 +152,7 @@ export default function PolitiqueDeConfidentialite() {
         </section>
 
         <section className="fr-mb-6w">
-          <h4 className="fr-mb-2w">Article 8 - Personnes concernées</h4>
+          <h4 className="fr-mb-2w">Article 7 - Personnes concernées</h4>
           <p className="fr-mb-2w">
             Sont concernées par le traitement mentionné à l&apos;article 3 les bénéficiaires
             éligibles au dispositif pass Sport et les exploitants de structures éligibles au
@@ -161,7 +161,7 @@ export default function PolitiqueDeConfidentialite() {
         </section>
 
         <section className="fr-mb-6w">
-          <h4 className="fr-mb-2w">Article 9 - Source des données</h4>
+          <h4 className="fr-mb-2w">Article 8 - Source des données</h4>
           <p>
             Vos données traitées ont été collectées indirectement. Elles nous ont été communiquées
             par le Centre National des Œuvres Universitaires et Scolaires Établissement public
@@ -171,7 +171,7 @@ export default function PolitiqueDeConfidentialite() {
         </section>
 
         <section className="fr-mb-6w">
-          <h4 className="fr-mb-2w">Article 10 - Nécessité de la collecte</h4>
+          <h4 className="fr-mb-2w">Article 9 - Nécessité de la collecte</h4>
           <p className="fr-mb-2w">
             Seules les données à caractère personnel nécessaires pour le traitement réalisé dans le
             cadre de la délivrance du pass Sport 2024 seront traitées.
@@ -184,7 +184,7 @@ export default function PolitiqueDeConfidentialite() {
         </section>
 
         <section className="fr-mb-6w">
-          <h4 className="fr-mb-2w">Article 11 - Quels sont vos droits ? Comment les exercer ?</h4>
+          <h4 className="fr-mb-2w">Article 10 - Quels sont vos droits ? Comment les exercer ?</h4>
           <p className="fr-mb-2w">
             Conformément à la règlementation applicable, vous disposez d&apos;un droit d&apos;accès,
             de rectification, d&apos;effacement, de limitation et d&apos;opposition des données qui
@@ -257,7 +257,7 @@ export default function PolitiqueDeConfidentialite() {
         </section>
 
         <section className="fr-mb-6w">
-          <h4 className="fr-mb-2w">Article 14 - Indications en cas de violation de données</h4>
+          <h4 className="fr-mb-2w">Article 11 - Indications en cas de violation de données</h4>
           <p className="fr-mb-2w">
             La Direction des sports s&apos;engage à mettre en œuvre toutes les mesures techniques et
             organisationnelles appropriées grâce à des moyens de sécurisation physiques et

--- a/site/src/app/v2/politique-de-confidentialite/style.module.scss
+++ b/site/src/app/v2/politique-de-confidentialite/style.module.scss
@@ -1,0 +1,19 @@
+@import '../../sassVariables.module';
+
+.wrapper {
+  max-width: $max-width;
+  margin: auto;
+  margin-top: 50px;
+  margin-bottom: 80px;
+  padding: 0 2rem;
+
+  @media screen and (max-width: $lg) {
+    padding: 0 1rem;
+  }
+}
+
+// Raise the specificity by adding twice the classname
+.page-header.page-header {
+  height: auto;
+  padding-bottom: 2rem;
+}

--- a/site/src/app/v2/politique-de-confidentialite/style.module.scss
+++ b/site/src/app/v2/politique-de-confidentialite/style.module.scss
@@ -10,6 +10,10 @@
   @media screen and (max-width: $lg) {
     padding: 0 1rem;
   }
+
+  &__text--center {
+    text-align: center;
+  }
 }
 
 // Raise the specificity by adding twice the classname


### PR DESCRIPTION
### Description
~~Draft, awaiting for confirmation of the page's content from David~~
Content updated

Implementation of pages:
- Données personnelles
- Mentions légales

### To confirm
- "Mentions légales" content OK? (It is a copy/paste from https://pass.sports.gouv.fr/mentions-legales/, but excluding the "Enquete" section)
- "Données personnelles" content OK? (The numbering seems OFF)

### Screenshot desktop + mobile données personnelles
![desktop](https://github.com/betagouv/pass-sport/assets/1215376/7bcc3276-563f-410b-93a8-22ee663a5c59)
![mobile](https://github.com/betagouv/pass-sport/assets/1215376/e7ab1d78-649e-48cf-9a82-4b9e6f2d805a)

### Screenshot desktop + mobile mentions légales
![desktop](https://github.com/betagouv/pass-sport/assets/1215376/c1359af3-1140-4b52-be4e-a8bd623cd676)
![mobile](https://github.com/betagouv/pass-sport/assets/1215376/942ed81e-5ae1-426f-82cf-61e3fb58ed70)

