### PR TITLE
[Frontend] Pass Sport navigation on mobile

### DIFF
--- a/site/src/app/components/pass-sport-navigation/navigation.tsx
+++ b/site/src/app/components/pass-sport-navigation/navigation.tsx
@@ -18,12 +18,7 @@ export const navigationItem: NavigationItem[] = [
   },
   {
     link: '/v2/tout-savoir-sur-le-pass-sport',
-    text: (
-      <div className={styles['menu-item-spacer']}>
-        <span aria-hidden="true"></span>
-        Tout savoir sur le pass Sport
-      </div>
-    ),
+    text: 'Tout savoir sur le pass Sport',
   },
   { link: '/v2/trouver-un-club', text: 'Trouver un club partenaire' },
   { link: '/v2/une-question', text: 'Une question ?' },


### PR DESCRIPTION
### Description
Tout savoir sur le pass'sport was not clickable on mobile
(Removed aria-hidden and only used text, because it is not necessary)


https://github.com/betagouv/pass-sport/assets/1215376/f6c60fa7-b1b9-468f-81a1-e11842fc6ff5

### Ticket
https://www.notion.so/Page-Tout-savoir-sur-le-Pass-Sport-cdb34d560f9b415e8093c35f4dc7ec94?d=0d392d8d5e6c429aba17672a34974a03