### PR TITLE
[Backend][Frontend] Handle rate limit error on FAQ

### DIFF
--- a/site/src/app/v2/une-question/components/ContentSection/ContentSection.tsx
+++ b/site/src/app/v2/une-question/components/ContentSection/ContentSection.tsx
@@ -28,9 +28,12 @@ export default function ContentSection({ categoriesWithArticles }: Props) {
           role="navigation"
           aria-labelledby="fr-summary-title"
         >
-          <p className="fr-summary__title fr-p-0 fr-pl-md-1w" id="fr-summary-title">
-            Categories
-          </p>
+          {categoriesWithArticles.length > 0 && (
+            <p className="fr-summary__title fr-p-0 fr-pl-md-1w" id="fr-summary-title">
+              Categories
+            </p>
+          )}
+
           <ol
             className={cn('fr-summary__list', 'fr-p-0', 'fr-pl-md-3w', styles['faq__summary-list'])}
           >

--- a/site/src/app/v2/une-question/server-agent.ts
+++ b/site/src/app/v2/une-question/server-agent.ts
@@ -10,14 +10,20 @@ const {
 } = initCrispClient();
 
 export const getCategoriesWithArticles = async (): Promise<CategoryWithArticles[]> => {
-  const articles = await getCrispArticles({
-    crispClient,
-    crispIdentifier: CRISP_WEBSITE,
-  });
+  try {
+    const articles = await getCrispArticles({
+      crispClient,
+      crispIdentifier: CRISP_WEBSITE,
+    });
 
-  return getFormattedCategories({
-    crispClient,
-    crispIdentifier: CRISP_WEBSITE,
-    articles,
-  });
+    return getFormattedCategories({
+      crispClient,
+      crispIdentifier: CRISP_WEBSITE,
+      articles,
+    });
+  } catch (err) {
+    console.error('Error occurred while trying to get articles from CRISP', err);
+
+    return [];
+  }
 };


### PR DESCRIPTION
## Description
Temporary fix, hide categories/articles when being hit by rate limit from CRISP API (we shouldn't be rate limited with our token)

This caused the page to crash