### PR TITLE
[Backend] In memory caching for FAQ Crisp API calls

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -13,6 +13,7 @@
         "crisp-api": "^8.3.2",
         "leaflet": "^1.9.4",
         "next": "14.1.1",
+        "node-cache": "^5.1.2",
         "react": "^18",
         "react-dom": "^18",
         "react-leaflet": "^4.2.1",
@@ -1575,6 +1576,14 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/clone-response": {
       "version": "1.0.3",
@@ -4639,6 +4648,17 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/node-cache": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
+      "dependencies": {
+        "clone": "2.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/node-fetch": {

--- a/site/package.json
+++ b/site/package.json
@@ -28,7 +28,8 @@
     "react-markdown": "^9.0.1",
     "react-select": "^5.8.0",
     "remark-breaks": "^4.0.0",
-    "zod": "^3.22.4"
+    "zod": "^3.22.4",
+    "node-cache": "^5.1.2"
   },
   "devDependencies": {
     "@types/leaflet": "^1.9.9",


### PR DESCRIPTION
# Description
Added in memory caching for API calls made to CRISP for getting articles/categories
Use of the library [node-cache](https://www.npmjs.com/package/node-cache)

# Ticket
https://www.notion.so/369742af22d9486097d69a9cc301c1c1?v=6e22fafc1b4f4333a53a8906eb814126&p=c317f92d7d5b4e1eaf2affccb958b58e&pm=s