### PR TITLE
[Frontend] Navigation fix + tout-savoir-sur-le-pass-sport UI fix + Breadcrumb fix

### DIFF
--- a/site/src/app/components/pass-sport-breadcrumb/PassSportBreadcrumbPro.tsx
+++ b/site/src/app/components/pass-sport-breadcrumb/PassSportBreadcrumbPro.tsx
@@ -27,7 +27,7 @@ export default function PassSportBreadcrumbPro() {
       <div className={cn(styles.container, styles['container--pro'])}>
         <div className={styles['container__breadcrumb']}>
           <Breadcrumb
-            homeLinkProps={{ href: '/v2/accueil' }}
+            homeLinkProps={{ href: '/v2/pro/accueil' }}
             currentPageLabel={NAVIGATION_ITEM_MAP[paths]}
             segments={[]}
             classes={{

--- a/site/src/app/components/pass-sport-navigation/navigation.tsx
+++ b/site/src/app/components/pass-sport-navigation/navigation.tsx
@@ -19,10 +19,12 @@ export const navigationItemStandard: NavigationItem[] = [
   {
     link: '/v2/tout-savoir-sur-le-pass-sport',
     text: (
-      <div className={styles['menu-item-spacer']}>
-        <span aria-hidden="true"></span>
+      <>
+        <div className={styles['menu-item-spacer']}>
+          <span aria-hidden="true"></span>
+        </div>
         Tout savoir sur le pass Sport
-      </div>
+      </>
     ),
   },
   { link: '/v2/trouver-un-club', text: 'Trouver un club partenaire' },
@@ -42,10 +44,12 @@ export const navigationItemPro: NavigationItem[] = [
   {
     link: '/v2/pro/tout-savoir-sur-le-pass-sport',
     text: (
-      <div className={styles['menu-item-spacer']}>
-        <span aria-hidden="true"></span>
+      <>
+        <div className={styles['menu-item-spacer']}>
+          <span aria-hidden="true"></span>
+        </div>
         Tout savoir sur le pass Sport
-      </div>
+      </>
     ),
   },
   { link: '/v2/pro/trouver-un-club', text: 'Trouver un club partenaire' },

--- a/site/src/app/v2/pro/tout-savoir-sur-le-pass-sport/page.tsx
+++ b/site/src/app/v2/pro/tout-savoir-sur-le-pass-sport/page.tsx
@@ -186,9 +186,8 @@ export default function ToutSavoirSurLePassSport() {
             Texte de référence Décret n° 2023-741 du 8 août 2023 relatif au « pass Sport » 2023
           </Link>
         </section>
-
-        <SocialMediaPanel isProVersion />
       </main>
+      <SocialMediaPanel isProVersion />
     </>
   );
 }


### PR DESCRIPTION
### Description
- After the re-introduction of the menu spacer item in the navigation, the "Tout savoir sur le pass sport" was no longer clickable again on mobile. The fix was to put the text alongside the div containing the styling for the spacer item
- Fix tout savoir sur le pass sport social media panel links UI (it used to not take the whole width)
- Fix on the Home page link in the pro version