### PR TITLE
[Frontend] FAQ - Various changes + testing environment for Paula & David

### DIFF
--- a/site/src/app/v2/pro/une-question/page.tsx
+++ b/site/src/app/v2/pro/une-question/page.tsx
@@ -1,18 +1,17 @@
 'use server';
 
 import PageHeader from '@/components/PageHeader/PageHeader';
-import EligibilityTestBanner from '@/components/eligibility-test-banner/EligibilityTestBanner';
-import SocialMediaPanel from '../../components/social-media-panel/SocialMediaPanel';
 import styles from './styles.module.scss';
 import ContentSection from '@/app/v2/une-question/components/ContentSection/ContentSection';
 import ContactSection from '@/app/v2/une-question/components/ContactSection/ContactSection';
 import { getCategoriesWithArticles } from '@/app/v2/une-question/server-agent';
 import { headers } from 'next/headers';
+import SocialMediaPanel from '@/app/components/social-media-panel/SocialMediaPanel';
 
 export default async function Questions() {
   headers();
 
-  const categoriesWithArticles = await getCategoriesWithArticles({ isProVersion: false });
+  const categoriesWithArticles = await getCategoriesWithArticles({ isProVersion: true });
 
   return (
     <>
@@ -22,12 +21,12 @@ export default async function Questions() {
         classes={{
           container: styles['page-header'],
         }}
+        isProVersion
       />
 
       <ContentSection categoriesWithArticles={categoriesWithArticles} />
       <ContactSection />
 
-      <EligibilityTestBanner />
       <SocialMediaPanel />
     </>
   );

--- a/site/src/app/v2/pro/une-question/styles.module.scss
+++ b/site/src/app/v2/pro/une-question/styles.module.scss
@@ -1,0 +1,20 @@
+@import '../../../sassVariables.module.scss';
+
+.summary {
+  background-color: var(--color-white);
+}
+
+.contact {
+  display: flex;
+  flex-direction: column;
+  gap: 48px;
+
+  max-width: 1200px;
+  margin: auto;
+}
+
+// Raise the specificity by adding twice the classname
+.page-header.page-header {
+  height: auto;
+  padding-bottom: 110px
+}

--- a/site/src/app/v2/une-question/components/ContactForm/ContactForm.tsx
+++ b/site/src/app/v2/une-question/components/ContactForm/ContactForm.tsx
@@ -10,7 +10,6 @@ import { InputsState } from '../../../../../../types/Contact';
 import { postContact } from '../../client-agent';
 import styles from './styles.module.scss';
 import { EMAIL_REGEX } from '../../../../../../utils/email';
-import Link from 'next/link';
 
 const initialInputsState: InputsState = {
   firstname: 'default',

--- a/site/src/app/v2/une-question/components/ContentSection/ContentSection.tsx
+++ b/site/src/app/v2/une-question/components/ContentSection/ContentSection.tsx
@@ -6,12 +6,15 @@ import React, { useState } from 'react';
 import cn from 'classnames';
 import Markdown from 'react-markdown';
 import remarkBreaks from 'remark-breaks';
+import { useRouter } from 'next/navigation';
 
 interface Props {
   categoriesWithArticles: CategoryWithArticles[];
 }
 
 export default function ContentSection({ categoriesWithArticles }: Props) {
+  const router = useRouter();
+
   const [selectedCategory, setSelectedCategory] = useState<CategoryWithArticles>(
     categoriesWithArticles[0],
   );
@@ -59,13 +62,18 @@ export default function ContentSection({ categoriesWithArticles }: Props) {
 
       <div className={styles['faq__questions']}>
         {selectedCategory?.articles.map((article) => {
+          if (selectedArticle !== null && article.id !== selectedArticle.id) return null;
+
           return (
             <div
               style={{ cursor: 'pointer' }}
-              onClick={() => setSelectedArticle(article)}
+              onClick={() => {
+                setSelectedArticle(article);
+                router.push(`#${article.id}`);
+              }}
               key={article.id}
             >
-              <div className="fr-callout">
+              <div className="fr-callout" id={article.id}>
                 <h3 className="fr-callout__title">{article.title}</h3>
                 <div className={cn('fr-callout__text', styles['faq__callout-text'])}>
                   <Markdown remarkPlugins={[remarkBreaks]} className={styles['faq__markdown']}>

--- a/site/src/app/v2/une-question/components/ContentSection/ContentSection.tsx
+++ b/site/src/app/v2/une-question/components/ContentSection/ContentSection.tsx
@@ -23,14 +23,18 @@ export default function ContentSection({ categoriesWithArticles }: Props) {
   // If there is an article id in the url
   // we need to set the selectedArticle and the selectedCategory associated to it
   if (articleId) {
-    categoriesWithArticles.forEach((category) => {
+    categoriesWithArticles.some((category) => {
       let articleFound = category.articles.find((article) => article.id === articleId);
 
       if (articleFound) {
         articleFromUrl = articleFound;
         defaultCategory = category;
-        return;
+
+        // break out of loop if found
+        return true;
       }
+
+      return false;
     });
   }
 
@@ -116,7 +120,10 @@ export default function ContentSection({ categoriesWithArticles }: Props) {
                       Retour
                     </button>
 
-                    <div className={cn(styles['faq__feedback-date'], 'fr-text--sm')}>
+                    <div
+                      className={cn(styles['faq__feedback-date'], 'fr-text--sm')}
+                      suppressHydrationWarning
+                    >
                       Mis à jour le : {new Date(selectedArticle.updatedAt).toLocaleDateString()}
                     </div>
                   </>

--- a/site/src/app/v2/une-question/server-agent.ts
+++ b/site/src/app/v2/une-question/server-agent.ts
@@ -9,7 +9,11 @@ const {
   crispClient,
 } = initCrispClient();
 
-export const getCategoriesWithArticles = async (): Promise<CategoryWithArticles[]> => {
+export const getCategoriesWithArticles = async ({
+  isProVersion,
+}: {
+  isProVersion: boolean;
+}): Promise<CategoryWithArticles[]> => {
   try {
     const articles = await getCrispArticles({
       crispClient,
@@ -20,6 +24,7 @@ export const getCategoriesWithArticles = async (): Promise<CategoryWithArticles[
       crispClient,
       crispIdentifier: CRISP_WEBSITE,
       articles,
+      isProVersion,
     });
   } catch (err) {
     console.error('Error occurred while trying to get articles from CRISP', err);

--- a/site/utils/faq.ts
+++ b/site/utils/faq.ts
@@ -6,8 +6,12 @@ import NodeCache from 'node-cache';
 type Locale = 'fr' | 'en';
 const LOCALE = 'fr';
 
-const CACHE_DURATION = 28_800; // 8 hours in seconds
-const cache = new NodeCache({ checkperiod: CACHE_DURATION, deleteOnExpire: true });
+const CACHE_DURATION = 1; // 8 hours in seconds
+const cache = new NodeCache({
+  checkperiod: CACHE_DURATION,
+  deleteOnExpire: true,
+  stdTTL: CACHE_DURATION,
+});
 export enum CacheKey {
   ARTICLES = 'ARTICLES',
   FULL_ARTICLE = 'FULL-ARTICLE',

--- a/site/utils/faq.ts
+++ b/site/utils/faq.ts
@@ -7,7 +7,7 @@ type Locale = 'fr' | 'en';
 const LOCALE = 'fr';
 
 const PRO_CATEGORY_IDENTIFIER = 'pro -';
-const USER_CATEGORY_IDENTIFIER = 'particulier -';
+const USER_CATEGORY_IDENTIFIER = 'bénéficiaire -';
 
 const CACHE_DURATION = 1; // 8 hours in seconds
 const cache = new NodeCache({

--- a/site/utils/faq.ts
+++ b/site/utils/faq.ts
@@ -9,12 +9,15 @@ const LOCALE = 'fr';
 const PRO_CATEGORY_IDENTIFIER = 'pro -';
 const USER_CATEGORY_IDENTIFIER = 'bénéficiaire -';
 
-const CACHE_DURATION = 1; // 8 hours in seconds
+const CACHE_DURATION = 28_800; // 8 hours in seconds
+const CHECK_PERIOD = 3_600; // 1 hour in seconds
+
 const cache = new NodeCache({
-  checkperiod: CACHE_DURATION,
+  checkperiod: CHECK_PERIOD,
   deleteOnExpire: true,
   stdTTL: CACHE_DURATION,
 });
+
 export enum CacheKey {
   ARTICLES = 'ARTICLES',
   FULL_ARTICLE = 'FULL-ARTICLE',


### PR DESCRIPTION
### Description
Staging environment for Paula & Julien to check FAQ articles/categories live without CACHE
Various changes:
- Selecting an article is now displaying ONE article fully expanded and not the whole list expanded
- Added support to link FAQ to one given article (articleId query parameter)
- Implemented pro version of the FAQ
- Use of category identifiers (Pro & User version) to get matching categories & articles depending on the page (pro or user version)


### Ticket
- https://www.notion.so/369742af22d9486097d69a9cc301c1c1?v=6e22fafc1b4f4333a53a8906eb814126&p=baf5f0d00aac40479a48c1f997faf980&pm=s
- https://www.notion.so/369742af22d9486097d69a9cc301c1c1?v=6e22fafc1b4f4333a53a8906eb814126&p=4be0f00b105c4363a89c3ec91fa70d33&pm=s
- https://www.notion.so/En-tant-que-structure-partenaire-je-souhaite-acc-der-la-FAQ-473b6eb40bf64c08917d649fab5bd5bd
