### PR TITLE
[Frontend] Header navigation added tableau de bord

### DIFF
--- a/site/src/app/components/pass-sport-navigation/PassSportNavigationPro.tsx
+++ b/site/src/app/components/pass-sport-navigation/PassSportNavigationPro.tsx
@@ -55,7 +55,7 @@ export default function PassSportNavigationPro() {
           isActive: isActive(item.link),
           linkProps: {
             href: item.link,
-            target: '_self',
+            target: !!item.isExternal ? '_blank' : '_self',
           },
           text: item.text,
         }))}

--- a/site/src/app/components/pass-sport-navigation/PassSportNavigationStandard.tsx
+++ b/site/src/app/components/pass-sport-navigation/PassSportNavigationStandard.tsx
@@ -46,7 +46,7 @@ export default function PassSportNavigation() {
           isActive: isActive(item.link),
           linkProps: {
             href: item.link,
-            target: '_self',
+            target: !!item.isExternal ? '_blank' : '_self',
           },
           text: item.text,
         }))}

--- a/site/src/app/components/pass-sport-navigation/navigation.tsx
+++ b/site/src/app/components/pass-sport-navigation/navigation.tsx
@@ -4,6 +4,7 @@ import styles from './styles.module.scss';
 type NavigationItem = {
   link: string;
   text: string | JSX.Element;
+  isExternal?: boolean;
 };
 
 export const navigationItemStandard: NavigationItem[] = [
@@ -20,15 +21,27 @@ export const navigationItemStandard: NavigationItem[] = [
     link: '/v2/tout-savoir-sur-le-pass-sport',
     text: (
       <>
-        <div className={styles['menu-item-spacer']}>
+        <span className={styles['menu-item-spacer']}>
           <span aria-hidden="true"></span>
-        </div>
+        </span>
         Tout savoir sur le pass Sport
       </>
     ),
   },
   { link: '/v2/trouver-un-club', text: 'Trouver un club partenaire' },
   { link: '/v2/une-question', text: 'Une question ?' },
+  {
+    link: 'https://lecompteasso.associations.gouv.fr/carto/dashboard',
+    isExternal: true,
+    text: (
+      <>
+        <div className={styles['menu-item-spacer']}>
+          <span aria-hidden="true"></span>
+        </div>
+        Tableau de bord
+      </>
+    ),
+  },
 ];
 
 export const navigationItemPro: NavigationItem[] = [
@@ -54,4 +67,16 @@ export const navigationItemPro: NavigationItem[] = [
   },
   { link: '/v2/pro/trouver-un-club', text: 'Carte des structures partenaires' },
   { link: '/v2/pro/une-question', text: 'Une question ?' },
+  {
+    link: 'https://lecompteasso.associations.gouv.fr/carto/dashboard',
+    isExternal: true,
+    text: (
+      <>
+        <div className={styles['menu-item-spacer']}>
+          <span aria-hidden="true"></span>
+        </div>
+        Tableau de bord
+      </>
+    ),
+  },
 ];

--- a/site/src/app/components/pass-sport-navigation/styles.module.scss
+++ b/site/src/app/components/pass-sport-navigation/styles.module.scss
@@ -8,7 +8,7 @@
     @media (min-width: $lg) {
       display: block;
       position: absolute;
-      left: -26px;
+      left: -13px;
       top: -3px;
       height: 30px;
       border-right: 1px solid #3a3a3a;


### PR DESCRIPTION
### Description
- Added Tableau de bord external link in user/pro version

### Ticket
https://www.notion.so/369742af22d9486097d69a9cc301c1c1?v=6e22fafc1b4f4333a53a8906eb814126&p=320a1b9091d341f084bb8a69b873c0d2&pm=s

![Screenshot 2024-05-22 at 17 34 40](https://github.com/betagouv/pass-sport/assets/1215376/e1ca9f88-5b03-4d0c-aed5-07e6e6e321f4)
![Screenshot 2024-05-22 at 17 34 44](https://github.com/betagouv/pass-sport/assets/1215376/0105293b-37e4-4e4f-b283-b52d1bdb551c)
