### PR TITLE
[Frontend] Updated typo for user/pro version in footer+header+breadcrumb

### DIFF
--- a/site/src/app/components/pass-sport-breadcrumb/PassSportBreadcrumbStandard.tsx
+++ b/site/src/app/components/pass-sport-breadcrumb/PassSportBreadcrumbStandard.tsx
@@ -9,7 +9,7 @@ import cn from 'classnames';
 export const NAVIGATION_ITEM_MAP: { [key: string]: string } = {
   '/v2/une-question': 'Une question ?',
   '/v2/tout-savoir-sur-le-pass-sport': 'Tout savoir sur le pass Sport',
-  '/v2/trouver-un-club': 'Trouver un club partenaire',
+  '/v2/trouver-un-club': 'Trouver une structure partenaire',
   '/v2/politique-de-confidentialite': 'Politique de confidentialité',
   '/v2/mentions-legales': 'Mentions légales',
 };
@@ -45,7 +45,7 @@ export default function PassSportBreadcrumbStandard() {
         homeLinkProps={{ href: '/v2/accueil' }}
         currentPageLabel={clubName}
         segments={[
-          { label: 'Trouver un club partenaire', linkProps: { href: '/v2/trouver-un-club' } },
+          { label: 'Trouver une structure partenaire', linkProps: { href: '/v2/trouver-un-club' } },
         ]}
       ></Breadcrumb>
     </div>

--- a/site/src/app/components/pass-sport-footer/PassSportFooter.tsx
+++ b/site/src/app/components/pass-sport-footer/PassSportFooter.tsx
@@ -176,7 +176,9 @@ export default function PassSportFooter() {
           },
         },
         {
-          text: 'Trouver une structure partenaire',
+          text: isProVersion
+            ? 'Carte des structures partenaires'
+            : 'Trouver une structure partenaire',
           linkProps: {
             href: isProVersion ? '/v2/pro/trouver-un-club' : '/v2/trouver-un-club',
           },

--- a/site/src/app/components/pass-sport-navigation/navigation.tsx
+++ b/site/src/app/components/pass-sport-navigation/navigation.tsx
@@ -28,7 +28,7 @@ export const navigationItemStandard: NavigationItem[] = [
       </>
     ),
   },
-  { link: '/v2/trouver-un-club', text: 'Trouver un club partenaire' },
+  { link: '/v2/trouver-un-club', text: 'Trouver une structure partenaire' },
   { link: '/v2/une-question', text: 'Une question ?' },
   {
     link: 'https://lecompteasso.associations.gouv.fr/carto/dashboard',

--- a/site/src/app/v2/accueil/components/find-club-card/FindClubCard.tsx
+++ b/site/src/app/v2/accueil/components/find-club-card/FindClubCard.tsx
@@ -16,7 +16,7 @@ const FindClubCard = () => {
       <div className="fr-card fr-card--no-border fr-card--lg fr-card--horizontal fr-card--horizontal-half">
         <div className="fr-card__body">
           <div className="fr-card__content">
-            <h4 className={`fr-card__title ${styles.title}`}>Trouver un club partenaire</h4>
+            <h4 className={`fr-card__title ${styles.title}`}>Trouver une structure partenaire</h4>
             <p className="fr-card__desc">
               Choisis le club de ton choix parmi plus de 85&nbsp;000 clubs et salles de sport
               partout en France !

--- a/site/src/app/v2/une-question/components/ContactForm/ContactForm.tsx
+++ b/site/src/app/v2/une-question/components/ContactForm/ContactForm.tsx
@@ -26,7 +26,7 @@ const reasons: string[] = [
   'Bénéficiaires et familles : qui reçoit le code ?',
   'Bénéficiaires et familles : comment utiliser mon pass ?',
   'Bénéficiaires et familles : où utiliser mon pass ?',
-  'Bénéficiaires et familles : comment trouver un club partenaire ?',
+  'Bénéficiaires et familles : comment trouver une structure partenaire ?',
   'Bénéficiaires et familles : mon club refuse de prendre le pass Sport que faire ?',
   "Bénéficiaires et familles : mon club refuse de me faire la réduction de 50€ à l’inscription et attend d'être remboursé pour m'appliquer la ristourne que faire ?",
   'Bénéficiaires et familles : les inscriptions dans mon club sont avant l’envoi des codes que faire ?',


### PR DESCRIPTION
### Description
Update the following wording in header + footer + breadcrumb
- "Trouver un club partenaire" => "Trouver une structure partenaire"
- "Carte des structures partenaires" remains unchanged
### Ticket
https://www.notion.so/Footer-Support-des-liens-en-version-pro-et-utilisateur-mettre-jour-le-niveau-de-conformit-acc-d301326c7de74c4ab96561c920c396a4