### PR TITLE
[Frontend] Footer - domains updated

### DIFF
--- a/site/src/app/components/pass-sport-footer/PassSportFooter.tsx
+++ b/site/src/app/components/pass-sport-footer/PassSportFooter.tsx
@@ -209,6 +209,8 @@ export default function PassSportFooter() {
     },
   ];
 
+  const domains = ['legifrance.gouv.fr', 'info.gouv.fr', 'service-public.fr', 'data.gouv.fr'];
+
   return (
     <Footer
       classes={{
@@ -223,6 +225,7 @@ export default function PassSportFooter() {
       linkList={linkList}
       brandTop={FOOTER_BRAND_TOP}
       accessibility="non compliant"
+      domains={domains}
     />
   );
 }


### PR DESCRIPTION
### Description
Link gouvernement.fr -> info.gouv.fr

The property **domains** is not documented in https://components.react-dsfr.codegouv.studio/?path=/docs/components-footer--default

I had to go into the DSFR's source code to know the existence of this props

### Ticket
https://www.notion.so/369742af22d9486097d69a9cc301c1c1?v=6e22fafc1b4f4333a53a8906eb814126&p=0621e252aa1d4263b0d5e4be8ce00361&pm=s