### PR TITLE
[Frontend] FAQ UX Improvements

### DIFF
--- a/site/components/PageHeader/PageHeader.tsx
+++ b/site/components/PageHeader/PageHeader.tsx
@@ -14,6 +14,8 @@ interface IProps {
 export default function PageHeader({ title, subtitle, classes, isProVersion = false }: IProps) {
   return (
     <header
+      // Mainly used as an anchor
+      id="header"
       className={cn(styles.container, classes?.container, {
         [styles['container--pro']]: isProVersion,
       })}

--- a/site/src/app/v2/une-question/components/ContentSection/ContentSection.tsx
+++ b/site/src/app/v2/une-question/components/ContentSection/ContentSection.tsx
@@ -66,6 +66,7 @@ export default function ContentSection({ categoriesWithArticles }: Props) {
               return (
                 <li
                   key={category.id}
+                  id={category.id}
                   onClick={() => {
                     setSelectedCategory(category);
                     setSelectedArticle(null);
@@ -95,11 +96,14 @@ export default function ContentSection({ categoriesWithArticles }: Props) {
 
           return (
             <div
+              id={article.id}
               style={{ cursor: 'pointer' }}
               onClick={() => {
-                setSelectedArticle(article);
-                replace(`${pathname}?articleId=${article.id}`);
-                push(['trackEvent', 'View FAQ', `Clicked`, `${article.title} (${article.id})`]);
+                if (selectedArticle === null) {
+                  setSelectedArticle(article);
+                  replace(`${pathname}?articleId=${article.id}#${article.id}`);
+                  push(['trackEvent', 'View FAQ', `Clicked`, `${article.title} (${article.id})`]);
+                }
               }}
               key={article.id}
             >
@@ -120,7 +124,7 @@ export default function ContentSection({ categoriesWithArticles }: Props) {
                         // on the article itself thus setting the selectedArticle again instead of setting it to null
                         e.stopPropagation();
                         setSelectedArticle(null);
-                        replace(`${pathname}`);
+                        replace(`${pathname}#header`);
                       }}
                     >
                       Retour

--- a/site/src/app/v2/une-question/components/ContentSection/ContentSection.tsx
+++ b/site/src/app/v2/une-question/components/ContentSection/ContentSection.tsx
@@ -66,7 +66,6 @@ export default function ContentSection({ categoriesWithArticles }: Props) {
               return (
                 <li
                   key={category.id}
-                  id={category.id}
                   onClick={() => {
                     setSelectedCategory(category);
                     setSelectedArticle(null);


### PR DESCRIPTION
### Description
- Sur la page détaillant un article, lorsque ce l’on clique dessus, il ne devrait pas y avoir de changement de page. (cela empêche de copier/coller du texte provenant de l’article)
- Lorsque l’on clique sur un article, le scroll devrait s’arrêter au niveau de l’article
- Lorsque l’on clique sur le bouton “Retour” d’un article, le scroll ne devrait pas aller tout en haut de la page mais plutôt au niveau du PageHeader

### Ticket
https://www.notion.so/369742af22d9486097d69a9cc301c1c1?v=6e22fafc1b4f4333a53a8906eb814126&p=164d489e35fb4b3490f2e20100bcdf8a&pm=s