### PR TITLE
[Frontend] Hide code in url before pushing event to matomo

### DIFF
--- a/site/src/app/Matomo.tsx
+++ b/site/src/app/Matomo.tsx
@@ -29,10 +29,10 @@ export default function Matomo() {
     const { pathname } = window.location;
 
     let updatedPathName = pathname;
-    let regex = /\/v2\/code\/scan\/.*/;
+    let regex = /\/code\/scan\/.*/;
 
     if (regex.test(pathname)) {
-      updatedPathName = pathname.replace(regex, `/v2/code/scan/24-xxxx-xxxx`);
+      updatedPathName = pathname.replace(regex, `/code/scan/24-xxxx-xxxx`);
     }
 
     push(['setCustomUrl', updatedPathName]);

--- a/site/src/app/Matomo.tsx
+++ b/site/src/app/Matomo.tsx
@@ -26,7 +26,16 @@ export default function Matomo() {
       push(['setReferrerUrl', previousURL]);
     }
 
-    push(['setCustomUrl', window.location.pathname]);
+    const { pathname } = window.location;
+
+    let updatedPathName = pathname;
+    let regex = /\/v2\/code\/scan\/.*/;
+
+    if (regex.test(pathname)) {
+      updatedPathName = pathname.replace(regex, `/v2/code/scan/24-xxxx-xxxx`);
+    }
+
+    push(['setCustomUrl', updatedPathName]);
     push(['trackPageView']);
 
     setPreviousURL(window.location.pathname);


### PR DESCRIPTION
### Description
In QR recap page, replace code with 24-xxxx-xxxx before pushing event to matomo

### Ticket
https://www.notion.so/369742af22d9486097d69a9cc301c1c1?v=6e22fafc1b4f4333a53a8906eb814126&p=f372de3c869d420889a998d652114d70&pm=s
