### PR TITLE
fix / handle bad status response from LCA /confirm

### DIFF
--- a/site/src/app/v2/api/eligibility-test/confirm/route.ts
+++ b/site/src/app/v2/api/eligibility-test/confirm/route.ts
@@ -31,7 +31,7 @@ export async function POST(request: Request) {
 
     if (!response.ok) {
       throw new Error(
-        `Request to LCA api on /confirm has failed. Response status is ${response.status}`,
+        `Request to LCA api on /confirm has failed. Response status is ${response.status}. Response body is ${await response.json()}`,
       );
     }
 

--- a/site/src/app/v2/api/eligibility-test/confirm/route.ts
+++ b/site/src/app/v2/api/eligibility-test/confirm/route.ts
@@ -28,6 +28,13 @@ export async function POST(request: Request) {
 
     const url: URL = buildLCAConfirmUrl(payload);
     const response = await fetch(url);
+
+    if (!response.ok) {
+      throw new Error(
+        `Request to LCA api on /confirm has failed. Response status is ${response.status}`,
+      );
+    }
+
     const responseBody = (await response.json()) as ConfirmResponseBody | ConfirmResponseErrorBody;
 
     if ('message' in responseBody) {


### PR DESCRIPTION
pas sur que ce soit la raison du bug "buildQRCodeUrl() Cannot destructure property 'nom' of 'e[0]' as it is undefined."
mais ca peut. 

