### PR TITLE
[Frontend] QR Code page recap - Replace double quotes with single quote

### DIFF
--- a/site/src/app/v2/code/scan/[encrypted]/page.tsx
+++ b/site/src/app/v2/code/scan/[encrypted]/page.tsx
@@ -36,10 +36,11 @@ function Page({ params: { encrypted } }: Props) {
   if (decryptedParams === null) return <InvalidContainer />;
 
   const searchParams = new URLSearchParams(decryptedParams);
+  const replaceDoubleQuotes = (input: string | null) => input?.replaceAll(`''`, `'`) || input;
 
   const [firstname, lastname, gender, birthDate, code] = [
-    searchParams.get('bp'),
-    searchParams.get('bn'),
+    replaceDoubleQuotes(searchParams.get('bp')),
+    replaceDoubleQuotes(searchParams.get('bn')),
     searchParams.get('bg'),
     searchParams.get('bdn'),
     searchParams.get('c'),


### PR DESCRIPTION
### Description
- On Recap QR code page, when displaying firstname and last name, replace double quotes with single quote

### Ticket
https://www.notion.so/369742af22d9486097d69a9cc301c1c1?v=6e22fafc1b4f4333a53a8906eb814126&p=c24e66d3991d4041bde0c8ab9c4ef067&pm=s