### PR TITLE
[Frontend] Attempt to fix code interception matomo

### DIFF
--- a/site/src/app/Matomo.tsx
+++ b/site/src/app/Matomo.tsx
@@ -38,7 +38,7 @@ export default function Matomo() {
     push(['setCustomUrl', updatedPathName]);
     push(['trackPageView']);
 
-    setPreviousURL(window.location.pathname);
+    setPreviousURL(updatedPathName);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [location]);
 


### PR DESCRIPTION
### Description
After console.logging window._paq (where matomo stuff is being put in), I noticed that the previousUrl was containing the qr code url, this PR aims to replace this pathname with the updated one (with the hidden code)

### Ticket
https://www.notion.so/369742af22d9486097d69a9cc301c1c1?v=6e22fafc1b4f4333a53a8906eb814126&p=825f525f5dd244ebb7dca1d428e04666&pm=s