### PR TITLE
[Frontend] header navigation, transformed buttons to links

### DIFF
--- a/site/src/app/components/pass-sport-navigation/PassSportNavigationPro.tsx
+++ b/site/src/app/components/pass-sport-navigation/PassSportNavigationPro.tsx
@@ -39,10 +39,8 @@ export default function PassSportNavigationPro() {
           {
             text: 'Je suis un particulier',
             iconId: 'fr-icon-arrow-right-line',
-            buttonProps: {
-              onClick: () => {
-                router.push('/v2/accueil');
-              },
+            linkProps: {
+              href: '/v2/accueil',
               className: 'fr-btn--tertiary fr-btn--icon-right',
             },
           },

--- a/site/src/app/components/pass-sport-navigation/PassSportNavigationStandard.tsx
+++ b/site/src/app/components/pass-sport-navigation/PassSportNavigationStandard.tsx
@@ -33,10 +33,8 @@ export default function PassSportNavigation() {
           {
             text: 'Je suis une structure partenaire',
             iconId: 'fr-icon-arrow-right-line',
-            buttonProps: {
-              onClick: () => {
-                router.push('/v2/pro/accueil');
-              },
+            linkProps: {
+              href: '/v2/pro/accueil',
               className: 'fr-btn--tertiary fr-btn--icon-right',
             },
           },


### PR DESCRIPTION
### Description
In the PassSportNavigation pro/user version, did the following
- "Je suis un particulier" from button to link
- "Je suis une structure partenaire" from button to link

### Ticket
https://www.notion.so/369742af22d9486097d69a9cc301c1c1?v=6e22fafc1b4f4333a53a8906eb814126&p=2aa60021b949421789054f5029f129e6&pm=s