### PR TITLE
[Frontend] Persist search in find a club page (added query parameters for all filters)

### DIFF
--- a/site/src/app/constants/search-query-params.ts
+++ b/site/src/app/constants/search-query-params.ts
@@ -1,0 +1,8 @@
+export const SEARCH_QUERY_PARAMS = {
+  clubName: 'clubName',
+  regionCode: 'regionCode',
+  city: 'city',
+  postalCode: 'postalCode',
+  activity: 'activity',
+  handicap: 'disability',
+};

--- a/site/src/app/hooks/use-append-query-string.tsx
+++ b/site/src/app/hooks/use-append-query-string.tsx
@@ -1,0 +1,25 @@
+import { useCallback } from 'react';
+import { useSearchParams } from 'next/navigation';
+
+export function useAppendQueryString() {
+  const searchParams = useSearchParams();
+
+  return useCallback(
+    (pairs: { key: string; value: string }[]) => {
+      if (searchParams === null) return '';
+
+      const params = new URLSearchParams(searchParams);
+
+      pairs.forEach(({ key, value }) => {
+        if (value === '') {
+          params.delete(key);
+        } else {
+          params.set(key, value);
+        }
+      });
+
+      return params.toString();
+    },
+    [searchParams],
+  );
+}

--- a/site/src/app/hooks/use-remove-query-string.tsx
+++ b/site/src/app/hooks/use-remove-query-string.tsx
@@ -1,0 +1,18 @@
+import { useSearchParams } from 'next/navigation';
+import { useCallback } from 'react';
+
+export function useRemoveQueryString() {
+  const searchParams = useSearchParams();
+
+  return useCallback(
+    (key: string) => {
+      if (searchParams === null) return '';
+
+      const params = new URLSearchParams(searchParams);
+      params.delete(key);
+
+      return params.toString();
+    },
+    [searchParams],
+  );
+}

--- a/site/src/app/v2/pro/trouver-un-club/page.tsx
+++ b/site/src/app/v2/pro/trouver-un-club/page.tsx
@@ -5,6 +5,7 @@ import ClubFinder from '@/app/v2/trouver-un-club/components/club-finder/ClubFind
 import { getAllClubActivities, getFranceRegions } from '@/app/v2/trouver-un-club/agent';
 import styles from './styles.module.scss';
 import { Metadata } from 'next';
+import { Suspense } from 'react';
 
 export const metadata: Metadata = {
   title: 'Carte des structures partenaires - pass Sport',
@@ -49,7 +50,9 @@ const TrouverUnClub = async () => {
           container: styles['page-header'],
         }}
       />
-      <ClubFinder regions={regions} activities={activities} isProVersion />
+      <Suspense>
+        <ClubFinder regions={regions} activities={activities} isProVersion />
+      </Suspense>
       <SocialMediaPanel isProVersion />
     </>
   );

--- a/site/src/app/v2/trouver-un-club/agent.ts
+++ b/site/src/app/v2/trouver-un-club/agent.ts
@@ -24,12 +24,14 @@ export const getClubs = async (param: SqlSearchParams): Promise<SportGouvJSONRes
   params.append('offset', param.offset.toString());
 
   let whereClause = 'nom is not null';
+
   whereClause += param?.clubName ? ` AND ${param.clubName}` : '';
   whereClause += param?.regionCode ? ` AND ${param.regionCode}` : '';
   whereClause += param?.city ? ` AND ${param.city}` : '';
   whereClause += param?.postalCode ? ` AND ${param.postalCode}` : '';
   whereClause += param?.activity ? ` AND ${param.activity}` : '';
   whereClause += param?.disability ? ` AND ${param.disability}` : '';
+
   params.append('where', whereClause);
 
   const url = new URL(baseUrl);
@@ -69,6 +71,38 @@ export const getFranceRegions = async (): Promise<GeoGouvRegion[]> => {
 
   const body = await response.json();
   return parseFranceRegions(body);
+};
+
+export const getFranceCitiesByPostalCode = async (
+  postalCode: string,
+  includeDistricts: boolean,
+): Promise<City[]> => {
+  const baseUrl = 'https://geo.api.gouv.fr/communes';
+
+  const params = new URLSearchParams();
+  params.append('limit', '20');
+  params.append('boost', 'population');
+  params.append('codePostal', postalCode);
+  params.append(
+    'type',
+    includeDistricts ? 'arrondissement-municipal,commune-actuelle' : 'commune-actuelle',
+  );
+
+  const url = new URL(baseUrl);
+  url.search = params.toString();
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    Sentry.withScope((scope) => {
+      scope.setLevel('warning');
+      scope.setExtra('responseBody', response.body);
+      scope.setExtra('responseStatus', response.status);
+      scope.captureMessage('Unexpected response from geo.api.gouv.fr for cities');
+    });
+    return [];
+  }
+
+  return response.json();
 };
 
 export const getFranceCitiesByName = async (

--- a/site/src/app/v2/trouver-un-club/components/club-filters/ClubFilters.tsx
+++ b/site/src/app/v2/trouver-un-club/components/club-filters/ClubFilters.tsx
@@ -1,17 +1,14 @@
-'use client';
-
-import RadioButtons from '@codegouvfr/react-dsfr/RadioButtons';
 import cn from 'classnames';
-import Select, { SingleValue } from 'react-select';
-import AsyncSelect from 'react-select/async';
-import { City } from 'types/City';
 import { ActivityResponse } from 'types/Club';
 import { GeoGouvRegion } from 'types/Region';
-import { getFranceCitiesByName } from '../../agent';
 import Search from '../search/Search';
 import RegionFilter from './region-filter/RegionFilter';
 import styles from './styles.module.scss';
 import { Suspense } from 'react';
+import { useSearchParams } from 'next/navigation';
+import CityFilter from '@/app/v2/trouver-un-club/components/club-filters/city-filter/CityFilter';
+import ActivityFilter from '@/app/v2/trouver-un-club/components/club-filters/activity-filter/ActivityFilter';
+import HandicapFilter from '@/app/v2/trouver-un-club/components/club-filters/handicap-filter/HandicapFilter';
 
 export interface Option {
   label: string;
@@ -25,7 +22,7 @@ interface Props {
   onRegionChanged: (region?: string) => void;
   onCityChanged: (cityOrPostalCode: { city?: string; postalCode?: string }) => void;
   onActivityChanged: (activity?: string) => void;
-  onDisabilityChanged: (isDisabled: 'Non' | 'Oui') => void;
+  onDisabilityChanged: (isActivated: boolean) => void;
 }
 
 export const selectStyles = {
@@ -63,57 +60,7 @@ const ClubFilters: React.FC<Props> = ({
   onActivityChanged,
   onDisabilityChanged,
 }) => {
-  const parsedActivities: Option[] = activities.results
-    .filter((activity) => activity.activites)
-    .map((activity) => ({
-      label: activity.activites,
-      value: activity.activites,
-    }));
-
-  const parseCities = (cities: City[]): Option[] =>
-    cities
-      .map((city) => {
-        const result: Option[] = [];
-        if (city.codesPostaux.length > 1) {
-          result.push({ label: city.nom, value: city.nom });
-        }
-        return result.concat(
-          city.codesPostaux.map((cp) => ({
-            label: `${city.nom} (${cp})`,
-            value: city.codesPostaux.length > 1 ? cp : city.nom,
-          })),
-        );
-      })
-      .flat();
-
-  const fetchCityOptions = (inputValue: string) =>
-    getFranceCitiesByName(inputValue, false).then((cities) => parseCities(cities));
-
-  const cityChangeHandler = (newValue: SingleValue<Option>) => {
-    if (!newValue) {
-      /* field was cleared */
-      onCityChanged({});
-    } else {
-      const cityOrPostalCode = newValue.value;
-      if (cityOrPostalCode === '') {
-        onCityChanged({});
-      }
-      if (isNaN(cityOrPostalCode as unknown as number)) {
-        onCityChanged({ city: newValue.value });
-      } else {
-        onCityChanged({ postalCode: newValue.value });
-      }
-    }
-  };
-
-  const activityChangeHandler = (newValue: SingleValue<Option>) => {
-    if (!newValue) {
-      /* field was cleared */
-      onActivityChanged();
-    } else {
-      onActivityChanged(newValue.value);
-    }
-  };
+  const searchParams = useSearchParams();
 
   return (
     <div className={cn('fr-pt-3w', 'fr-pb-2w', styles.container)}>
@@ -127,73 +74,22 @@ const ClubFilters: React.FC<Props> = ({
               <RegionFilter regions={regions} onRegionChanged={onRegionChanged} />
             </Suspense>
           </div>
-          <div className={styles.separator} />
-          <div className={cn(styles.flex)}>
-            <div className={styles['label-container']}>
-              <label htmlFor="city" className={styles.label}>
-                Ville
-              </label>
-              <AsyncSelect
-                instanceId="city-select-id"
-                name="city"
-                loadingMessage={() => <p>Chargement des villes</p>}
-                noOptionsMessage={() => <p>Aucune ville trouvée</p>}
-                placeholder="Toutes les villes"
-                cacheOptions
-                isClearable
-                loadOptions={fetchCityOptions}
-                onChange={cityChangeHandler}
-                styles={selectStyles}
-              />
-            </div>
-          </div>
-          <div className={styles.separator} />
-          <div className={cn(styles.flex)}>
-            <div className={styles['label-container']}>
-              <label htmlFor="activity" className={styles.label}>
-                Activités
-              </label>
-              <div className={styles['input-container']}>
-                <span className={cn('ri-basketball-line', styles.icon)} />
 
-                <Select
-                  instanceId="activities-select-id"
-                  className={styles.select}
-                  isClearable
-                  isSearchable
-                  name="activity"
-                  placeholder="Toutes les activités"
-                  options={parsedActivities}
-                  onChange={activityChangeHandler}
-                  styles={selectStyles}
-                />
-              </div>
-            </div>
-          </div>
           <div className={styles.separator} />
-          <RadioButtons
-            className={cn(styles.flex, 'fr-mx-0', styles.radio, 'fr-mb-0')}
-            legend="Accueil de personnes en situation de handicaps"
-            name="disability"
-            small
-            options={[
-              {
-                label: 'Oui',
-                nativeInputProps: {
-                  value: 'oui',
-                  onChange: () => onDisabilityChanged('Oui'),
-                },
-              },
-              {
-                label: 'Non',
-                nativeInputProps: {
-                  value: 'non',
-                  onChange: () => onDisabilityChanged('Non'),
-                },
-              },
-            ]}
-            orientation="horizontal"
-          />
+
+          <div className={cn(styles.flex)}>
+            <CityFilter onCityChanged={onCityChanged} />
+          </div>
+
+          <div className={styles.separator} />
+
+          <div className={cn(styles.flex)}>
+            <ActivityFilter onActivityChanged={onActivityChanged} activities={activities} />
+          </div>
+
+          <div className={styles.separator} />
+
+          <HandicapFilter onDisabilityChanged={onDisabilityChanged} />
         </div>
       </div>
     </div>

--- a/site/src/app/v2/trouver-un-club/components/club-filters/ClubFilters.tsx
+++ b/site/src/app/v2/trouver-un-club/components/club-filters/ClubFilters.tsx
@@ -67,32 +67,24 @@ const ClubFilters: React.FC<Props> = ({
         <p className={cn('fr-text--sm', 'fr-py-2w', 'fr-mb-0', styles.title)}>Filtrer par :</p>
         <div className={styles.filtersContainer}>
           <div className={cn(styles.flex)}>
-            <Suspense>
-              <RegionFilter regions={regions} onRegionChanged={onRegionChanged} />
-            </Suspense>
+            <RegionFilter regions={regions} onRegionChanged={onRegionChanged} />
           </div>
 
           <div className={styles.separator} />
 
           <div className={cn(styles.flex)}>
-            <Suspense>
-              <CityFilter onCityChanged={onCityChanged} />
-            </Suspense>
+            <CityFilter onCityChanged={onCityChanged} />
           </div>
 
           <div className={styles.separator} />
 
           <div className={cn(styles.flex)}>
-            <Suspense>
-              <ActivityFilter onActivityChanged={onActivityChanged} activities={activities} />
-            </Suspense>
+            <ActivityFilter onActivityChanged={onActivityChanged} activities={activities} />
           </div>
 
           <div className={styles.separator} />
 
-          <Suspense>
-            <HandicapFilter onDisabilityChanged={onDisabilityChanged} />
-          </Suspense>
+          <HandicapFilter onDisabilityChanged={onDisabilityChanged} />
         </div>
       </div>
     </div>

--- a/site/src/app/v2/trouver-un-club/components/club-filters/ClubFilters.tsx
+++ b/site/src/app/v2/trouver-un-club/components/club-filters/ClubFilters.tsx
@@ -27,13 +27,13 @@ export const selectStyles = {
   control: (baseStyles: Record<string, unknown>) => ({
     ...baseStyles,
     borderColor: '#ffffff',
-    '@media screen and (max-width: 768px)': {
-      width: '100%',
-    },
+    width: '210px',
     '@media screen and (max-width: 992px)': {
       width: '150px',
     },
-    width: '210px',
+    '@media screen and (max-width: 768px)': {
+      width: '100%',
+    },
   }),
   indicatorSeparator: (baseStyles: Record<string, unknown>) => ({
     ...baseStyles,

--- a/site/src/app/v2/trouver-un-club/components/club-filters/ClubFilters.tsx
+++ b/site/src/app/v2/trouver-un-club/components/club-filters/ClubFilters.tsx
@@ -5,7 +5,6 @@ import Search from '../search/Search';
 import RegionFilter from './region-filter/RegionFilter';
 import styles from './styles.module.scss';
 import { Suspense } from 'react';
-import { useSearchParams } from 'next/navigation';
 import CityFilter from '@/app/v2/trouver-un-club/components/club-filters/city-filter/CityFilter';
 import ActivityFilter from '@/app/v2/trouver-un-club/components/club-filters/activity-filter/ActivityFilter';
 import HandicapFilter from '@/app/v2/trouver-un-club/components/club-filters/handicap-filter/HandicapFilter';
@@ -60,8 +59,6 @@ const ClubFilters: React.FC<Props> = ({
   onActivityChanged,
   onDisabilityChanged,
 }) => {
-  const searchParams = useSearchParams();
-
   return (
     <div className={cn('fr-pt-3w', 'fr-pb-2w', styles.container)}>
       <div className="fr-px-2w">
@@ -78,18 +75,24 @@ const ClubFilters: React.FC<Props> = ({
           <div className={styles.separator} />
 
           <div className={cn(styles.flex)}>
-            <CityFilter onCityChanged={onCityChanged} />
+            <Suspense>
+              <CityFilter onCityChanged={onCityChanged} />
+            </Suspense>
           </div>
 
           <div className={styles.separator} />
 
           <div className={cn(styles.flex)}>
-            <ActivityFilter onActivityChanged={onActivityChanged} activities={activities} />
+            <Suspense>
+              <ActivityFilter onActivityChanged={onActivityChanged} activities={activities} />
+            </Suspense>
           </div>
 
           <div className={styles.separator} />
 
-          <HandicapFilter onDisabilityChanged={onDisabilityChanged} />
+          <Suspense>
+            <HandicapFilter onDisabilityChanged={onDisabilityChanged} />
+          </Suspense>
         </div>
       </div>
     </div>

--- a/site/src/app/v2/trouver-un-club/components/club-filters/ClubFilters.tsx
+++ b/site/src/app/v2/trouver-un-club/components/club-filters/ClubFilters.tsx
@@ -4,7 +4,6 @@ import { GeoGouvRegion } from 'types/Region';
 import Search from '../search/Search';
 import RegionFilter from './region-filter/RegionFilter';
 import styles from './styles.module.scss';
-import { Suspense } from 'react';
 import CityFilter from '@/app/v2/trouver-un-club/components/club-filters/city-filter/CityFilter';
 import ActivityFilter from '@/app/v2/trouver-un-club/components/club-filters/activity-filter/ActivityFilter';
 import HandicapFilter from '@/app/v2/trouver-un-club/components/club-filters/handicap-filter/HandicapFilter';

--- a/site/src/app/v2/trouver-un-club/components/club-filters/activity-filter/ActivityFilter.tsx
+++ b/site/src/app/v2/trouver-un-club/components/club-filters/activity-filter/ActivityFilter.tsx
@@ -5,6 +5,7 @@ import styles from '../styles.module.scss';
 import { SEARCH_QUERY_PARAMS } from '@/app/constants/search-query-params';
 import { ActivityResponse } from '../../../../../../../types/Club';
 import { useSearchParams } from 'next/navigation';
+import { unescapeSingleQuotes } from '../../../../../../../utils/string';
 
 interface Props {
   onActivityChanged: (activity?: string) => void;
@@ -29,9 +30,12 @@ const ActivityFilter = ({ onActivityChanged, activities }: Props) => {
   };
 
   const searchParams = useSearchParams();
-  const activitySearchParams = searchParams && searchParams.get(SEARCH_QUERY_PARAMS.activity);
+  const unescapedActivity = unescapeSingleQuotes(
+    searchParams?.get(SEARCH_QUERY_PARAMS.activity) || '',
+  );
+
   const defaultActivityOption: Option | undefined = parsedActivities.find(
-    (r) => r.value === activitySearchParams,
+    (r) => r.value === unescapedActivity,
   );
 
   return (

--- a/site/src/app/v2/trouver-un-club/components/club-filters/activity-filter/ActivityFilter.tsx
+++ b/site/src/app/v2/trouver-un-club/components/club-filters/activity-filter/ActivityFilter.tsx
@@ -3,7 +3,6 @@ import Select, { SingleValue } from 'react-select';
 import { Option, selectStyles } from '@/app/v2/trouver-un-club/components/club-filters/ClubFilters';
 import styles from '../styles.module.scss';
 import { SEARCH_QUERY_PARAMS } from '@/app/constants/search-query-params';
-import { useEffect } from 'react';
 import { ActivityResponse } from '../../../../../../../types/Club';
 import { useSearchParams } from 'next/navigation';
 
@@ -34,11 +33,6 @@ const ActivityFilter = ({ onActivityChanged, activities }: Props) => {
   const defaultActivityOption: Option | undefined = parsedActivities.find(
     (r) => r.value === activitySearchParams,
   );
-
-  useEffect(() => {
-    onActivityChanged(defaultActivityOption?.value);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   return (
     <div className={styles['label-container']}>

--- a/site/src/app/v2/trouver-un-club/components/club-filters/activity-filter/ActivityFilter.tsx
+++ b/site/src/app/v2/trouver-un-club/components/club-filters/activity-filter/ActivityFilter.tsx
@@ -1,0 +1,68 @@
+import cn from 'classnames';
+import Select, { SingleValue } from 'react-select';
+import { Option, selectStyles } from '@/app/v2/trouver-un-club/components/club-filters/ClubFilters';
+import styles from '../styles.module.scss';
+import { SEARCH_QUERY_PARAMS } from '@/app/constants/search-query-params';
+import { useEffect } from 'react';
+import { ActivityResponse } from '../../../../../../../types/Club';
+import { useSearchParams } from 'next/navigation';
+
+interface Props {
+  onActivityChanged: (activity?: string) => void;
+  activities: ActivityResponse;
+}
+
+const ActivityFilter = ({ onActivityChanged, activities }: Props) => {
+  const parsedActivities: Option[] = activities.results
+    .filter((activity) => activity.activites)
+    .map((activity) => ({
+      label: activity.activites,
+      value: activity.activites,
+    }));
+
+  const activityChangeHandler = (newValue: SingleValue<Option>) => {
+    if (!newValue) {
+      /* field was cleared */
+      onActivityChanged();
+    } else {
+      onActivityChanged(newValue.value);
+    }
+  };
+
+  const searchParams = useSearchParams();
+  const activitySearchParams = searchParams && searchParams.get(SEARCH_QUERY_PARAMS.activity);
+  const defaultActivityOption: Option | undefined = parsedActivities.find(
+    (r) => r.value === activitySearchParams,
+  );
+
+  useEffect(() => {
+    onActivityChanged(defaultActivityOption?.value);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <div className={styles['label-container']}>
+      <label htmlFor="activity" className={styles.label}>
+        Activités
+      </label>
+      <div className={styles['input-container']}>
+        <span className={cn('ri-basketball-line', styles.icon)} />
+
+        <Select
+          defaultValue={defaultActivityOption}
+          instanceId="activities-select-id"
+          className={styles.select}
+          isClearable
+          isSearchable
+          name="activity"
+          placeholder="Toutes les activités"
+          options={parsedActivities}
+          onChange={activityChangeHandler}
+          styles={selectStyles}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default ActivityFilter;

--- a/site/src/app/v2/trouver-un-club/components/club-filters/city-filter/CityFilter.tsx
+++ b/site/src/app/v2/trouver-un-club/components/club-filters/city-filter/CityFilter.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { getFranceCitiesByName, getFranceCitiesByPostalCode } from '@/app/v2/trouver-un-club/agent';
 import { SingleValue } from 'react-select';
 import { Option, selectStyles } from '@/app/v2/trouver-un-club/components/club-filters/ClubFilters';

--- a/site/src/app/v2/trouver-un-club/components/club-filters/city-filter/CityFilter.tsx
+++ b/site/src/app/v2/trouver-un-club/components/club-filters/city-filter/CityFilter.tsx
@@ -1,0 +1,127 @@
+import { getFranceCitiesByName, getFranceCitiesByPostalCode } from '@/app/v2/trouver-un-club/agent';
+import { SingleValue } from 'react-select';
+import { Option, selectStyles } from '@/app/v2/trouver-un-club/components/club-filters/ClubFilters';
+import { City } from '../../../../../../../types/City';
+import { useEffect, useState } from 'react';
+import { SEARCH_QUERY_PARAMS } from '@/app/constants/search-query-params';
+import { useSearchParams } from 'next/navigation';
+import styles from '../styles.module.scss';
+import AsyncSelect from 'react-select/async';
+
+interface Props {
+  onCityChanged: (cityOrPostalCode: { city?: string; postalCode?: string }) => void;
+}
+
+const CityFilter = ({ onCityChanged }: Props) => {
+  const searchParams = useSearchParams();
+
+  const citySearchParams = searchParams && searchParams.get(SEARCH_QUERY_PARAMS.city);
+  const postalCodeSearchParams = searchParams && searchParams.get(SEARCH_QUERY_PARAMS.postalCode);
+
+  const cityChangeHandler = (newValue: SingleValue<Option>) => {
+    if (!newValue) {
+      /* field was cleared */
+      onCityChanged({});
+    } else {
+      const cityOrPostalCode = newValue.value;
+      if (cityOrPostalCode === '') {
+        onCityChanged({});
+      }
+      if (isNaN(cityOrPostalCode as unknown as number)) {
+        onCityChanged({ city: newValue.value });
+      } else {
+        onCityChanged({ postalCode: newValue.value });
+      }
+    }
+  };
+
+  let [defaultOption, setDefaultOption] = useState<Option>({ label: '', value: '' });
+
+  useEffect(() => {
+    const city = (searchParams && searchParams.get(SEARCH_QUERY_PARAMS.city)) || '';
+    const postalCode = (searchParams && searchParams.get(SEARCH_QUERY_PARAMS.postalCode)) || '';
+
+    if (postalCode) {
+      getFranceCitiesByPostalCode(postalCode, false).then((cities) => {
+        const formattedCities = parseCities(cities);
+        const matchingCityWithPostalCode = formattedCities.find(
+          ({ value, label }) => value === postalCode,
+        );
+
+        if (matchingCityWithPostalCode !== undefined) {
+          setDefaultOption(matchingCityWithPostalCode);
+        }
+      });
+    }
+    if (city) {
+      getFranceCitiesByName(city, false).then((cities) => {
+        parseCities(cities);
+        setDefaultOption(parseCities(cities)[0]);
+      });
+    }
+  }, [citySearchParams, postalCodeSearchParams, searchParams]);
+
+  return (
+    <div className={styles['label-container']}>
+      <label htmlFor="city" className={styles.label}>
+        Ville
+      </label>
+      {(citySearchParams || postalCodeSearchParams) && defaultOption?.value?.length > 0 ? (
+        <AsyncSelect
+          instanceId="city-select-id"
+          name="city"
+          key="city-select-with-search-param"
+          loadingMessage={() => <p>Chargement des villes</p>}
+          noOptionsMessage={() => <p>Aucune ville trouvée</p>}
+          placeholder="Toutes les villes"
+          cacheOptions
+          isClearable
+          loadOptions={fetchCityOptions}
+          onChange={cityChangeHandler}
+          styles={selectStyles}
+          defaultInputValue={defaultOption.label}
+          defaultValue={defaultOption}
+        />
+      ) : (
+        <AsyncSelect
+          instanceId="city-select-id"
+          name="city"
+          key="city-select-without-search-param"
+          loadingMessage={() => <p>Chargement des villes</p>}
+          noOptionsMessage={() => <p>Aucune ville trouvée</p>}
+          placeholder="Toutes les villes"
+          cacheOptions
+          isClearable
+          loadOptions={fetchCityOptions}
+          onChange={cityChangeHandler}
+          styles={selectStyles}
+        />
+      )}
+    </div>
+  );
+};
+
+function parseCities(cities: City[]): Option[] {
+  return cities
+    .map((city) => {
+      const result: Option[] = [];
+
+      if (city.codesPostaux.length > 1) {
+        result.push({ label: city.nom, value: city.nom });
+      }
+
+      return result.concat(
+        city.codesPostaux.map((cp) => ({
+          label: `${city.nom} (${cp})`,
+          value: city.codesPostaux.length > 1 ? cp : city.nom,
+        })),
+      );
+    })
+    .flat();
+}
+
+function fetchCityOptions(inputValue: string) {
+  return getFranceCitiesByName(inputValue, false).then((cities) => parseCities(cities));
+}
+
+export default CityFilter;

--- a/site/src/app/v2/trouver-un-club/components/club-filters/handicap-filter/HandicapFilter.tsx
+++ b/site/src/app/v2/trouver-un-club/components/club-filters/handicap-filter/HandicapFilter.tsx
@@ -1,0 +1,31 @@
+import cn from 'classnames';
+import styles from '@/app/v2/trouver-un-club/components/club-filters/styles.module.scss';
+import { SEARCH_QUERY_PARAMS } from '@/app/constants/search-query-params';
+import { useSearchParams } from 'next/navigation';
+import ToggleSwitch from '@codegouvfr/react-dsfr/ToggleSwitch';
+
+interface Props {
+  onDisabilityChanged: (isActivated: boolean) => void;
+}
+
+const HandicapFilter = ({ onDisabilityChanged }: Props) => {
+  const searchParams = useSearchParams();
+  const toggleActivated = searchParams && searchParams.get(SEARCH_QUERY_PARAMS.handicap) === 'Oui';
+
+  return (
+    <ToggleSwitch
+      inputTitle="test"
+      className={cn(styles.flex, 'fr-mx-0', styles.radio, 'fr-mb-0')}
+      label="Accueil des personnes en situation de handicaps uniquement"
+      name="disability"
+      onChange={(isActivated) => {
+        onDisabilityChanged(isActivated);
+      }}
+      {...(toggleActivated && {
+        defaultChecked: true,
+      })}
+    />
+  );
+};
+
+export default HandicapFilter;

--- a/site/src/app/v2/trouver-un-club/components/club-filters/region-filter/RegionFilter.tsx
+++ b/site/src/app/v2/trouver-un-club/components/club-filters/region-filter/RegionFilter.tsx
@@ -1,12 +1,13 @@
 'use client';
 
 import cn from 'classnames';
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useSearchParams } from 'next/navigation';
 import Select, { SingleValue } from 'react-select';
 import { GeoGouvRegion } from '../../../../../../../types/Region';
 import { selectStyles, Option } from '../ClubFilters';
 import styles from '../styles.module.scss';
 import { useEffect } from 'react';
+import { SEARCH_QUERY_PARAMS } from '@/app/constants/search-query-params';
 
 interface Props {
   regions: GeoGouvRegion[];
@@ -15,9 +16,7 @@ interface Props {
 
 const RegionFilter: React.FC<Props> = ({ regions, onRegionChanged }) => {
   const searchParam = useSearchParams();
-  const regionCodeSearchParam = searchParam && searchParam.get('regionCode');
-  const router = useRouter();
-  const pathname = usePathname();
+  const regionCodeSearchParam = searchParam && searchParam.get(SEARCH_QUERY_PARAMS.regionCode);
 
   const parsedRegions: Option[] = regions.map((region) => ({
     label: region.nom,
@@ -35,11 +34,8 @@ const RegionFilter: React.FC<Props> = ({ regions, onRegionChanged }) => {
 
   const regionChangeHandler = (newValue: SingleValue<Option>) => {
     if (!newValue) {
-      /* field was cleared */
       onRegionChanged();
-      router.push(`${pathname}`);
     } else {
-      router.push(`${pathname}?regionCode=${newValue.value}`);
       onRegionChanged(newValue.value);
     }
   };

--- a/site/src/app/v2/trouver-un-club/components/club-filters/region-filter/RegionFilter.tsx
+++ b/site/src/app/v2/trouver-un-club/components/club-filters/region-filter/RegionFilter.tsx
@@ -27,11 +27,6 @@ const RegionFilter: React.FC<Props> = ({ regions, onRegionChanged }) => {
     (r) => r.value === regionCodeSearchParam,
   );
 
-  useEffect(() => {
-    onRegionChanged(defaultRegionOption?.value);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
   const regionChangeHandler = (newValue: SingleValue<Option>) => {
     if (!newValue) {
       onRegionChanged();

--- a/site/src/app/v2/trouver-un-club/components/club-filters/styles.module.scss
+++ b/site/src/app/v2/trouver-un-club/components/club-filters/styles.module.scss
@@ -47,7 +47,6 @@
 
     .select {
       flex-grow: 1;
-      z-index: 2;
     }
   }
 }

--- a/site/src/app/v2/trouver-un-club/components/club-finder/ClubFinder.tsx
+++ b/site/src/app/v2/trouver-un-club/components/club-finder/ClubFinder.tsx
@@ -84,11 +84,14 @@ const ClubFinder = ({ regions, activities, isProVersion }: Props) => {
 
   const searchClubByTextHandler = (text: string) => {
     const params: SqlSearchParams = { ...clubParams, offset: 0, clubName: undefined };
+    const escapedText = escapeSingleQuotes(text);
 
     if (text.length !== 0) {
-      params.clubName = `nom like '%${escapeSingleQuotes(text).toUpperCase()}%'`;
+      params.clubName = `nom like '%${escapedText.toUpperCase()}%'`;
 
-      const queryString = appendQueryString([{ key: SEARCH_QUERY_PARAMS.clubName, value: text }]);
+      const queryString = appendQueryString([
+        { key: SEARCH_QUERY_PARAMS.clubName, value: escapedText },
+      ]);
 
       router.push(`${pathname}?${queryString}`, { scroll: false });
     } else {
@@ -171,14 +174,16 @@ const ClubFinder = ({ regions, activities, isProVersion }: Props) => {
       const queryString = removeQueryString(SEARCH_QUERY_PARAMS.activity);
       router.push(`${pathname}?${queryString}`, { scroll: false });
     } else {
+      const escapedSingleQuotesActivity = escapeSingleQuotes(activity);
+
       setClubParams((clubParams) => ({
         ...clubParams,
         offset: 0,
-        activity: `activites='${escapeSingleQuotes(activity)}'`,
+        activity: `activites='${escapedSingleQuotesActivity}'`,
       }));
 
       const queryString = appendQueryString([
-        { key: SEARCH_QUERY_PARAMS.activity, value: activity },
+        { key: SEARCH_QUERY_PARAMS.activity, value: escapedSingleQuotesActivity },
       ]);
 
       router.push(`${pathname}?${queryString}`, { scroll: false });

--- a/site/src/app/v2/trouver-un-club/components/club-finder/ClubFinder.tsx
+++ b/site/src/app/v2/trouver-un-club/components/club-finder/ClubFinder.tsx
@@ -4,8 +4,8 @@ import { Badge } from '@codegouvfr/react-dsfr/Badge';
 import { Card } from '@codegouvfr/react-dsfr/Card';
 import { Tag } from '@codegouvfr/react-dsfr/Tag';
 import styles from './style.module.scss';
-import { Suspense, useEffect, useState } from 'react';
-import { SqlSearchParams, getClubs } from '../../agent';
+import { useEffect, useState } from 'react';
+import { getClubs, SqlSearchParams } from '../../agent';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import Button from '@codegouvfr/react-dsfr/Button';
 import ClubFilters from '../club-filters/ClubFilters';
@@ -75,7 +75,7 @@ const ClubFinder = ({ regions, activities, isProVersion }: Props) => {
         }),
       );
     }
-  }, [clubName, regionCode, city, postalCode, activity, disability, offset]);
+  }, [clubName, regionCode, city, postalCode, activity, disability, offset, clubParams]);
 
   const seeMoreClubsHandler = () => {
     setClubParams((clubParams) => ({ ...clubParams, offset: clubParams.offset + limit }));
@@ -89,11 +89,11 @@ const ClubFinder = ({ regions, activities, isProVersion }: Props) => {
 
       const queryString = appendQueryString([{ key: SEARCH_QUERY_PARAMS.clubName, value: text }]);
 
-      router.push(`${pathname}?${queryString}`);
+      router.push(`${pathname}?${queryString}`, { scroll: false });
     } else {
       const queryString = removeQueryString(SEARCH_QUERY_PARAMS.clubName);
 
-      router.push(`${pathname}?${queryString}`);
+      router.push(`${pathname}?${queryString}`, { scroll: false });
     }
 
     setClubParams(params);
@@ -104,7 +104,7 @@ const ClubFinder = ({ regions, activities, isProVersion }: Props) => {
       setClubParams((clubParams) => ({ ...clubParams, offset: 0, regionCode: undefined }));
 
       const queryString = removeQueryString(SEARCH_QUERY_PARAMS.regionCode);
-      router.push(`${pathname}?${queryString}`);
+      router.push(`${pathname}?${queryString}`, { scroll: false });
     } else {
       setClubParams((clubParams) => ({
         ...clubParams,
@@ -116,7 +116,7 @@ const ClubFinder = ({ regions, activities, isProVersion }: Props) => {
         { key: SEARCH_QUERY_PARAMS.regionCode, value: region },
       ]);
 
-      router.push(`${pathname}?${queryString}`);
+      router.push(`${pathname}?${queryString}`, { scroll: false });
     }
   };
 
@@ -152,14 +152,14 @@ const ClubFinder = ({ regions, activities, isProVersion }: Props) => {
         { key: SEARCH_QUERY_PARAMS.postalCode, value: '' },
       ]);
 
-      router.push(`${pathname}?${queryString}`);
+      router.push(`${pathname}?${queryString}`, { scroll: false });
     } else {
       const queryString = appendQueryString([
         { key: SEARCH_QUERY_PARAMS.city, value: '' },
         { key: SEARCH_QUERY_PARAMS.postalCode, value: postalCode?.toUpperCase() || '' },
       ]);
 
-      router.push(`${pathname}?${queryString}`);
+      router.push(`${pathname}?${queryString}`, { scroll: false });
     }
   };
 
@@ -168,7 +168,7 @@ const ClubFinder = ({ regions, activities, isProVersion }: Props) => {
       setClubParams((clubParams) => ({ ...clubParams, offset: 0, activity: undefined }));
 
       const queryString = removeQueryString(SEARCH_QUERY_PARAMS.activity);
-      router.push(`${pathname}?${queryString}`);
+      router.push(`${pathname}?${queryString}`, { scroll: false });
     } else {
       setClubParams((clubParams) => ({
         ...clubParams,
@@ -180,7 +180,7 @@ const ClubFinder = ({ regions, activities, isProVersion }: Props) => {
         { key: SEARCH_QUERY_PARAMS.activity, value: activity },
       ]);
 
-      router.push(`${pathname}?${queryString}`);
+      router.push(`${pathname}?${queryString}`, { scroll: false });
     }
   };
 
@@ -195,7 +195,7 @@ const ClubFinder = ({ regions, activities, isProVersion }: Props) => {
       ? appendQueryString([{ key: SEARCH_QUERY_PARAMS.handicap, value: 'Oui' }])
       : removeQueryString(SEARCH_QUERY_PARAMS.handicap);
 
-    router.push(`${pathname}?${queryString}`);
+    router.push(`${pathname}?${queryString}`, { scroll: false });
   };
 
   const isLastPage = clubs.total_count === clubs.results.length;

--- a/site/src/app/v2/trouver-un-club/components/club-finder/ClubFinder.tsx
+++ b/site/src/app/v2/trouver-un-club/components/club-finder/ClubFinder.tsx
@@ -18,6 +18,7 @@ import { DisabilityTag } from '../disability-tag/DisabilityTag';
 import { SEARCH_QUERY_PARAMS } from '@/app/constants/search-query-params';
 import { useAppendQueryString } from '@/app/hooks/use-append-query-string';
 import { useRemoveQueryString } from '@/app/hooks/use-remove-query-string';
+import { escapeSingleQuotes } from '../../../../../../utils/string';
 
 interface Props {
   regions: GeoGouvRegion[];
@@ -85,7 +86,7 @@ const ClubFinder = ({ regions, activities, isProVersion }: Props) => {
     const params: SqlSearchParams = { ...clubParams, offset: 0, clubName: undefined };
 
     if (text.length !== 0) {
-      params.clubName = `nom like '%${text.toUpperCase()}%'`;
+      params.clubName = `nom like '%${escapeSingleQuotes(text).toUpperCase()}%'`;
 
       const queryString = appendQueryString([{ key: SEARCH_QUERY_PARAMS.clubName, value: text }]);
 
@@ -173,7 +174,7 @@ const ClubFinder = ({ regions, activities, isProVersion }: Props) => {
       setClubParams((clubParams) => ({
         ...clubParams,
         offset: 0,
-        activity: `activites='${activity}'`,
+        activity: `activites='${escapeSingleQuotes(activity)}'`,
       }));
 
       const queryString = appendQueryString([

--- a/site/src/app/v2/trouver-un-club/components/club-finder/ClubFinder.tsx
+++ b/site/src/app/v2/trouver-un-club/components/club-finder/ClubFinder.tsx
@@ -45,6 +45,9 @@ const ClubFinder = ({ regions, activities, isProVersion }: Props) => {
       [SEARCH_QUERY_PARAMS.clubName]: searchParams.get(SEARCH_QUERY_PARAMS.clubName)
         ? `nom like '%${searchParams.get(SEARCH_QUERY_PARAMS.clubName)!.toUpperCase()}%'`
         : undefined,
+      [SEARCH_QUERY_PARAMS.regionCode]: searchParams.get(SEARCH_QUERY_PARAMS.regionCode)
+        ? `reg_code='${searchParams.get(SEARCH_QUERY_PARAMS.regionCode)}'`
+        : undefined,
       [SEARCH_QUERY_PARAMS.city]: searchParams.get(SEARCH_QUERY_PARAMS.city)
         ? `commune='${searchParams.get(SEARCH_QUERY_PARAMS.city)!.toUpperCase()}'`
         : undefined,

--- a/site/src/app/v2/trouver-un-club/components/club-finder/ClubFinder.tsx
+++ b/site/src/app/v2/trouver-un-club/components/club-finder/ClubFinder.tsx
@@ -200,17 +200,15 @@ const ClubFinder = ({ regions, activities, isProVersion }: Props) => {
   return (
     <>
       <div className={styles.spacer}>
-        <Suspense>
-          <ClubFilters
-            regions={regions}
-            activities={activities}
-            onTextSearch={searchClubByTextHandler}
-            onRegionChanged={onRegionChanged}
-            onCityChanged={onCityChanged}
-            onActivityChanged={onActivityChanged}
-            onDisabilityChanged={onDisabilityChanged}
-          />
-        </Suspense>
+        <ClubFilters
+          regions={regions}
+          activities={activities}
+          onTextSearch={searchClubByTextHandler}
+          onRegionChanged={onRegionChanged}
+          onCityChanged={onCityChanged}
+          onActivityChanged={onActivityChanged}
+          onDisabilityChanged={onDisabilityChanged}
+        />
 
         <ClubCount displayedClubCount={clubs.results.length} totalClubCount={clubs.total_count} />
 

--- a/site/src/app/v2/trouver-un-club/components/search/Search.tsx
+++ b/site/src/app/v2/trouver-un-club/components/search/Search.tsx
@@ -1,12 +1,15 @@
 import { SearchBar } from '@codegouvfr/react-dsfr/SearchBar';
 import { useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { SEARCH_QUERY_PARAMS } from '@/app/constants/search-query-params';
 
 interface IProps {
   onTextSearch: (text: string) => void;
 }
 
 export default function Search({ onTextSearch }: IProps) {
-  const [search, onSearchChange] = useState('');
+  const searchParams = useSearchParams();
+  const [search, onSearchChange] = useState(searchParams?.get(SEARCH_QUERY_PARAMS.clubName) || '');
 
   return (
     <SearchBar
@@ -24,7 +27,16 @@ export default function Search({ onTextSearch }: IProps) {
           // Note: The default behavior for an input of type 'text' is to clear the input value when the escape key is pressed.
           // However, due to a bug in @gouvfr/dsfr the escape key event is not propagated to the input element.
           // As a result this onChange is not called when the escape key is pressed.
-          onChange={(event) => onSearchChange(event.currentTarget.value)}
+          onChange={(event) => {
+            const search = event.currentTarget.value;
+
+            // Handle the case where search is empty in order to update the query parameter clubName
+            if (search.length === 0) {
+              onTextSearch('');
+            }
+
+            onSearchChange(search);
+          }}
           // Same goes for the keydown event so this is useless but we hope the bug will be fixed soon.
         />
       )}

--- a/site/src/app/v2/trouver-un-club/components/search/Search.tsx
+++ b/site/src/app/v2/trouver-un-club/components/search/Search.tsx
@@ -2,6 +2,7 @@ import { SearchBar } from '@codegouvfr/react-dsfr/SearchBar';
 import { useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { SEARCH_QUERY_PARAMS } from '@/app/constants/search-query-params';
+import { unescapeSingleQuotes } from '../../../../../../utils/string';
 
 interface IProps {
   onTextSearch: (text: string) => void;
@@ -9,7 +10,8 @@ interface IProps {
 
 export default function Search({ onTextSearch }: IProps) {
   const searchParams = useSearchParams();
-  const [search, onSearchChange] = useState(searchParams?.get(SEARCH_QUERY_PARAMS.clubName) || '');
+  const clubName = unescapeSingleQuotes(searchParams?.get(SEARCH_QUERY_PARAMS.clubName) || '');
+  const [search, onSearchChange] = useState(clubName);
 
   return (
     <SearchBar

--- a/site/src/app/v2/trouver-un-club/page.tsx
+++ b/site/src/app/v2/trouver-un-club/page.tsx
@@ -4,6 +4,7 @@ import { getAllClubActivities, getFranceRegions } from './agent';
 import ClubFinder from './components/club-finder/ClubFinder';
 import SocialMediaPanel from '@/app/components/social-media-panel/SocialMediaPanel';
 import { Metadata } from 'next';
+import { Suspense } from 'react';
 
 export const metadata: Metadata = {
   title: 'Trouver un club partenaire - pass Sport',
@@ -16,7 +17,9 @@ const TrouverUnClub = async () => {
   return (
     <>
       <PageHeader title="Trouver un club" />
-      <ClubFinder regions={regions} activities={activities} />
+      <Suspense>
+        <ClubFinder regions={regions} activities={activities} />
+      </Suspense>
       <SocialMediaPanel />
     </>
   );

--- a/site/utils/string.ts
+++ b/site/utils/string.ts
@@ -1,3 +1,7 @@
 export function escapeSingleQuotes(value: string) {
   return value.replaceAll(`'`, `\\'`);
 }
+
+export function unescapeSingleQuotes(value: string) {
+  return value.replaceAll(`\\'`, `'`);
+}

--- a/site/utils/string.ts
+++ b/site/utils/string.ts
@@ -1,0 +1,3 @@
+export function escapeSingleQuotes(value: string) {
+  return value.replaceAll(`'`, `\\'`);
+}


### PR DESCRIPTION
### Description
- Added persistence for all filters except the pagination
- Turned handicap filter into toggle switch
- Added bug fixes when searching for activities & club names containing single quotes (escape single quote before making API calls)

### Ticket
https://www.notion.so/369742af22d9486097d69a9cc301c1c1?v=6e22fafc1b4f4333a53a8906eb814126&p=e3dd8cdd2e484d1eabb2d222b9d363d3&pm=s

### Todo
~~QA my own work~~