### PR TITLE
[Frontend] Background color updated

### DIFF
--- a/site/components/PageHeader/styles.module.scss
+++ b/site/components/PageHeader/styles.module.scss
@@ -1,7 +1,7 @@
 @import '../../src/app/sassVariables.module.scss';
 
 .container {
-  background-color: var(--background-contrast-blue-france);
+  background-color: var(--blue-ecume-925-125);
   height: 180px;
   padding: 0 1rem;
 

--- a/site/src/app/components/pass-sport-breadcrumb/styles.module.scss
+++ b/site/src/app/components/pass-sport-breadcrumb/styles.module.scss
@@ -1,7 +1,7 @@
 @import '../../../app/sassVariables.module.scss';
 
 .container {
-  background-color: var(--background-contrast-blue-france);
+  background-color: var(--blue-ecume-925-125);
   padding: 2rem 1.5rem;
 
   &--pro {

--- a/site/src/app/components/social-media-panel/styles.module.scss
+++ b/site/src/app/components/social-media-panel/styles.module.scss
@@ -3,7 +3,7 @@
 .container {
   display: flex;
   flex-direction: column;
-  background-color: var(--background-contrast-info);
+  background-color: var(--blue-ecume-925-125);
   align-items: center;
   gap: 24px;
   padding-top: 24px;


### PR DESCRIPTION
### Description
Background color updated for:
- Breadcrumb, 
- Page header,
- Social media links panel

### Ticket
https://www.notion.so/369742af22d9486097d69a9cc301c1c1?v=6e22fafc1b4f4333a53a8906eb814126&p=c728fb21096041819f07954f2d7d9f63&pm=s

### Screenshots
<img width="1728" alt="Screenshot 2024-06-11 at 16 05 01" src="https://github.com/betagouv/pass-sport/assets/1215376/7abf1d8a-d400-4100-9fab-5cb1cecb0fc6">
<img width="1728" alt="Screenshot 2024-06-11 at 16 04 56" src="https://github.com/betagouv/pass-sport/assets/1215376/44f04ec2-2b30-4495-adf9-d046cf6ded9e">
