### PR TITLE
remove calls to obsolete lca api routes

### DIFF
--- a/site/src/app/services/__snapshots__/eligibility-test.spec.ts.snap
+++ b/site/src/app/services/__snapshots__/eligibility-test.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`eligibility-test service fetchEligible using api v1 should return eligible data when eligible exists 1`] = `
+exports[`eligibility-test service fetchEligible should return eligible data when eligible exists 1`] = `
 [
   {
     "date_naissance": "2011-01-01T23:00:00.000Z",
@@ -14,21 +14,7 @@ exports[`eligibility-test service fetchEligible using api v1 should return eligi
 ]
 `;
 
-exports[`eligibility-test service fetchEligible using api v2 should return eligible data when eligible exists 1`] = `
-[
-  {
-    "date_naissance": "2011-01-01T23:00:00.000Z",
-    "id": 123,
-    "matricule": "9999999999999",
-    "nom": "DUPOND",
-    "organisme": "MSA",
-    "prenom": "MANON",
-    "situation": "jeune",
-  },
-]
-`;
-
-exports[`eligibility-test service fetchQrCode using api v1 should return eligible data enhanced with a qrcode url when eligible exists 1`] = `
+exports[`eligibility-test service fetchQrCode should return eligible data enhanced with a qrcode url when eligible exists 1`] = `
 [
   {
     "a_valider": false,
@@ -70,44 +56,3 @@ exports[`eligibility-test service fetchQrCode using api v1 should return eligibl
 ]
 `;
 
-exports[`eligibility-test service fetchQrCode using api v2 should return eligible data enhanced with a qrcode url when eligible exists 1`] = `
-[
-  {
-    "a_valider": false,
-    "adresse": {
-      "code_insee": "29098",
-      "code_postal": "29810",
-      "commune": "LAMPAUL PLOUARZEL",
-      "nom_adresse_postale": "MME DUPOND BABETTE",
-      "voie": "31 RUE DU TEST",
-    },
-    "allocataire": {
-      "code_insee_commune_naissance": "38000",
-      "code_organisme": "220",
-      "commune_naissance": "GRENOBLE",
-      "courriel": "fake_email@test.fr",
-      "date_naissance": "01/08/1979",
-      "matricule": "9999999999999",
-      "nom": "DUPOND",
-      "prenom": "BABETTE",
-      "qualite": "Mme",
-      "telephone": "0600000000",
-    },
-    "created_at": "2024-04-24T14:09:47.646+02:00",
-    "date_naissance": "2011-01-01T02:00:00.000+01:00",
-    "exercice_id": 4,
-    "genre": "F",
-    "id": 12967588,
-    "id_psp": "24-IIII-IIII",
-    "nom": "DUPOND",
-    "nom_complet": "MANON DUPOND",
-    "organisme": "MSA",
-    "prenom": "MANON",
-    "qrcodeUrl": "fake-qrcode-url",
-    "refuser": false,
-    "situation": "jeune",
-    "updated_at": "2023-08-31T12:05:34.000+02:00",
-    "uuid_doc": null,
-  },
-]
-`;

--- a/site/src/app/services/eligibility-test.ts
+++ b/site/src/app/services/eligibility-test.ts
@@ -11,7 +11,7 @@ import * as Sentry from '@sentry/nextjs';
 import { addQrCodeToConfirmResponse } from './qr-code';
 import { sanitize } from '../../../utils/eligibility-test';
 
-export const buildLCAConfirmUrl = (data: ConfirmPayload, isUsingApiV1: boolean): URL => {
+export const buildLCAConfirmUrl = (data: ConfirmPayload): URL => {
   const domain = process.env.LCA_API_URL;
 
   if (!domain) {
@@ -53,16 +53,14 @@ export const buildLCAConfirmUrl = (data: ConfirmPayload, isUsingApiV1: boolean):
     params.append('codeIso', sanitize(recipientBirthCountry));
   }
 
-  const baseUrl = isUsingApiV1
-    ? `${domain}/gw/psp-server/beneficiaires/confirm`
-    : `${domain}/apim/api-asso-admin/passsport/beneficiaires/confirm`;
+  const baseUrl = `${domain}/apim/api-asso-admin/passsport/beneficiaires/confirm`;
 
   const url = new URL(baseUrl);
   url.search = params.toString();
   return url;
 };
 
-export const buildLCASearchUrl = (data: SearchPayload, isUsingApiV1: boolean): URL => {
+export const buildLCASearchUrl = (data: SearchPayload): URL => {
   const domain = process.env.LCA_API_URL;
 
   if (!domain) {
@@ -75,9 +73,7 @@ export const buildLCASearchUrl = (data: SearchPayload, isUsingApiV1: boolean): U
   params.append('dateNaissance', sanitize(data.beneficiaryBirthDate));
   params.append('codeInsee', sanitize(data.recipientResidencePlace));
 
-  const baseUrl = isUsingApiV1
-    ? `${domain}/gw/psp-server/beneficiaires/search`
-    : `${domain}/apim/api-asso-admin/passsport/beneficiaires/search`;
+  const baseUrl = `${domain}/apim/api-asso-admin/passsport/beneficiaires/search`;
 
   const url = new URL(baseUrl);
   url.search = params.toString();
@@ -94,21 +90,16 @@ export const fetchQrCode = async (
     throw new Error('LCA authentication key is missing');
   }
 
-  const url: URL = buildLCAConfirmUrl(payload, true);
-  const url2 = buildLCAConfirmUrl(payload, false);
+  const url: URL = buildLCAConfirmUrl(payload);
 
-  const [response1, response2] = await Promise.all([
-    fetch(url),
-    fetch(url2, { headers: { 'X-Gravitee-Api-Key': authenticationKey } }),
-  ]);
+  const response = await fetch(url, { headers: { 'X-Gravitee-Api-Key': authenticationKey } });
 
-  if (!response2.ok && !response1.ok) {
+  if (!response.ok) {
     throw new Error(
-      `Request to LCA api on /confirm has failed. API V1: Response status is ${response1.status}; Response body is ${JSON.stringify(await response1.json())}. API V2: Response status is ${response2.status}; Response body is ${JSON.stringify(await response2.json())}`,
+      `Request to LCA api on /confirm has failed. Response status is ${response.status}; Response body is ${JSON.stringify(await response.json())}.`,
     );
   }
 
-  const response = !response2.ok ? response1 : response2;
   const responseBody = (await response.json()) as ConfirmResponseBody | ConfirmResponseErrorBody;
 
   if ('message' in responseBody) {
@@ -133,21 +124,16 @@ export const fetchEligible = async (payload: SearchPayload) => {
     throw new Error('LCA authentication key is missing');
   }
 
-  const url: URL = buildLCASearchUrl(payload, true);
-  const url2: URL = buildLCASearchUrl(payload, false);
+  const url: URL = buildLCASearchUrl(payload);
 
-  const [response1, response2] = await Promise.all([
-    fetch(url),
-    fetch(url2, { headers: { 'X-Gravitee-Api-Key': authenticationKey } }),
-  ]);
+  const response = await fetch(url, { headers: { 'X-Gravitee-Api-Key': authenticationKey } });
 
-  if (!response2.ok && !response1.ok) {
+  if (!response.ok) {
     throw new Error(
-      `Request to LCA api on /search has failed. API V1: Response status is ${response1.status}; Response body is ${JSON.stringify(await response1.json())}. API V2: Response status is ${response2.status}; Response body is ${JSON.stringify(await response2.json())}`,
+      `Request to LCA api on /search has failed. Response status is ${response.status}; Response body is ${JSON.stringify(await response.json())}`,
     );
   }
 
-  const response = !response2.ok ? response1 : response2;
   const responseBody = (await response.json()) as SearchResponseBody | SearchResponseErrorBody;
 
   if ('message' in responseBody) {

--- a/site/tests/api/eligibility-test/search/__snapshots__/route.test.ts.snap
+++ b/site/tests/api/eligibility-test/search/__snapshots__/route.test.ts.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`POST /eligibility-test/search should return fetched data 1`] = `
+[
+  {
+    "date_naissance": "2011-01-01T23:00:00.000Z",
+    "id": 123,
+    "matricule": "9999999999999",
+    "nom": "DUPOND",
+    "organisme": "MSA",
+    "prenom": "MANON",
+    "situation": "jeune",
+  },
+]
+`;

--- a/site/tests/api/eligibility-test/search/route.test.ts
+++ b/site/tests/api/eligibility-test/search/route.test.ts
@@ -1,0 +1,111 @@
+/**
+ * @jest-environment node
+ */
+
+import { fetchEligible } from '@/app/services/eligibility-test';
+import { POST } from '@/app/v2/api/eligibility-test/search/route';
+import { buildSearchResponseBody } from '../../../../tests/helpers/builders/confirm-response-body';
+import { SearchResponseBody } from 'types/EligibilityTest';
+
+jest.mock('../../../../src/app/services/eligibility-test', () => {
+  const original = jest.requireActual('../../../../src/app/services/eligibility-test');
+  return {
+    ...original,
+    fetchEligible: jest.fn(),
+  };
+});
+
+describe('POST /eligibility-test/search', () => {
+  const badRequestTests = [
+    {
+      msg: 'beneficiaryLastname is not provided',
+      data: [
+        { key: 'beneficiaryFirstname', value: 'bob' },
+        { key: 'beneficiaryBirthDate', value: '2015-03-28' },
+        { key: 'recipientResidencePlace', value: '05024' },
+      ],
+    },
+    {
+      msg: 'beneficiaryFirstname is not provided',
+      data: [
+        { key: 'beneficiaryLastname', value: 'marley' },
+        { key: 'beneficiaryBirthDate', value: '2015-03-28' },
+        { key: 'recipientResidencePlace', value: '05024' },
+      ],
+    },
+    {
+      msg: 'beneficiaryBirthDate is not provided',
+      data: [
+        { key: 'beneficiaryFirstname', value: 'bob' },
+        { key: 'beneficiaryLastname', value: 'marley' },
+        { key: 'recipientResidencePlace', value: '05024' },
+      ],
+    },
+    {
+      msg: 'recipientResidencePlace is not provided',
+      data: [
+        { key: 'beneficiaryFirstname', value: 'bob' },
+        { key: 'beneficiaryLastname', value: 'marley' },
+        { key: 'beneficiaryBirthDate', value: '2015-03-28' },
+      ],
+    },
+  ];
+
+  it.each(badRequestTests)('return a 400 when $msg ', async ({ data }) => {
+    const payload = new FormData();
+    data.forEach((item) => {
+      payload.append(item.key, item.value);
+    });
+
+    const request = new Request('http://localhost/api/eligibility-test/search', {
+      method: 'POST',
+      body: payload,
+    });
+
+    const response = await POST(request);
+    expect(response.status).toEqual(400);
+  });
+
+  it('should return fetched data', async () => {
+    const payload = new FormData();
+    payload.append('beneficiaryLastname', 'DUPOND');
+    payload.append('beneficiaryFirstname', 'MANON');
+    payload.append('beneficiaryBirthDate', '2011-01-01');
+    payload.append('recipientResidencePlace', '05024');
+
+    const request = new Request('http://localhost/api/eligibility-test/search', {
+      method: 'POST',
+      body: payload,
+    });
+
+    const mockedFetchEligible = fetchEligible as jest.Mock;
+    const mockedResponse: SearchResponseBody = [{ ...buildSearchResponseBody()[0] }];
+    mockedFetchEligible.mockResolvedValueOnce(mockedResponse);
+
+    const response = await POST(request);
+    expect(response.status).toEqual(200);
+    const body = await response.json();
+    expect(body).toMatchSnapshot();
+  });
+
+  it('should return an error 500 when LCA fetching throws', async () => {
+    const payload = new FormData();
+    payload.append('beneficiaryLastname', 'DUPOND');
+    payload.append('beneficiaryFirstname', 'MANON');
+    payload.append('beneficiaryBirthDate', '2011-01-01');
+    payload.append('recipientResidencePlace', '05024');
+
+    const request = new Request('http://localhost/api/eligibility-test/search', {
+      method: 'POST',
+      body: payload,
+    });
+
+    const mockedFetchQrCode = fetchEligible as jest.Mock;
+    mockedFetchQrCode.mockImplementationOnce(() => {
+      throw new Error();
+    });
+
+    const response = await POST(request);
+    expect(response.status).toEqual(500);
+  });
+});


### PR DESCRIPTION
[ticket](https://www.notion.so/Supprimer-le-double-appel-l-api-LCA-97a201d7f5c24c3fa38733bf837654e0?pvs=4)

[review app](https://pass-sport-staging-pr177.osc-secnum-fr1.scalingo.io)