### PR TITLE
fix / disable automatic tracking for matomo

### DIFF
--- a/site/src/app/Matomo.tsx
+++ b/site/src/app/Matomo.tsx
@@ -12,6 +12,7 @@ export default function Matomo() {
       init({
         url: process.env.NEXT_PUBLIC_MATOMO_URL || '',
         siteId: process.env.NEXT_PUBLIC_MATOMO_SITE_ID || '',
+        excludeUrlsPatterns: [/^\//],
       });
     }
     IS_MATOMO_INITIALIZED = true;


### PR DESCRIPTION
the package "@socialgouv/matomo-next" automatically tracks page view via the init function via a trackpageview call. In addition, this automatic tracking is partially disfunctional on next 14. 

=> this fix disables completely the automatic tracking from this package. 

the operational remaining tracking is the tracking mechanism written manually in the Matomo.tsx file.