### PR TITLE
[Frontend] Plan du site, background color updated

### DIFF
--- a/site/src/app/v2/plan-du-site/style.module.scss
+++ b/site/src/app/v2/plan-du-site/style.module.scss
@@ -1,7 +1,7 @@
 @import '../../sassVariables.module';
 
 .wrapper {
-  background-color: var(--background-contrast-blue-france);
+  background-color: var(--blue-ecume-925-125);
   padding-bottom: 72px;
 }
 


### PR DESCRIPTION
### Description
Before ->
<img width="1728" alt="Screenshot 2024-06-17 at 14 08 04" src="https://github.com/betagouv/pass-sport/assets/1215376/8faed2c6-691f-4451-90da-e6a4b6862ce9">

After ->
<img width="1728" alt="Screenshot 2024-06-17 at 14 12 51" src="https://github.com/betagouv/pass-sport/assets/1215376/6c6c8594-1bd7-4b14-b23d-0874452821e3">

### Ticket
https://www.notion.so/369742af22d9486097d69a9cc301c1c1?v=6e22fafc1b4f4333a53a8906eb814126&p=99e1b296a1544b45b3f1f87354171dfb&pm=s