### PR TITLE
[Frontend] Eligibility test - Enable inputs when failure

### DIFF
--- a/site/src/app/v2/test-eligibilite/components/step-one-form/StepOneForm.tsx
+++ b/site/src/app/v2/test-eligibilite/components/step-one-form/StepOneForm.tsx
@@ -66,7 +66,6 @@ const StepOneForm = ({ onDataReceived, onEligibilityFailure }: Props) => {
     }
 
     await requestEligibilityTest().then(({ status, body }) => {
-      setIsFormDisabled(true);
       if (status !== 200) {
         notifyError(status, body as SearchResponseErrorBody);
       } else {
@@ -79,6 +78,8 @@ const StepOneForm = ({ onDataReceived, onEligibilityFailure }: Props) => {
 
         if (body?.length === 0) {
           onEligibilityFailure();
+        } else {
+          setIsFormDisabled(true);
         }
       }
     });

--- a/site/src/app/v2/test-eligibilite/components/step-two-forms/AahCafForm.tsx
+++ b/site/src/app/v2/test-eligibilite/components/step-two-forms/AahCafForm.tsx
@@ -102,7 +102,6 @@ const AahCafForm = ({
         body: EnhancedConfirmResponseBody | ConfirmResponseErrorBody;
         status: number;
       }) => {
-        setIsFormDisabled(true);
         if (status !== 200) {
           notifyError(status);
         } else {
@@ -110,10 +109,12 @@ const AahCafForm = ({
             notifyError(status);
             return;
           }
+
           onDataReceived(body);
 
           if (body?.length > 0) {
             onEligibilitySuccess();
+            setIsFormDisabled(true);
           } else {
             onEligibilityFailure();
           }

--- a/site/src/app/v2/test-eligibilite/components/step-two-forms/AahMsaForm.tsx
+++ b/site/src/app/v2/test-eligibilite/components/step-two-forms/AahMsaForm.tsx
@@ -97,7 +97,6 @@ const AahMsaForm = ({
         body: EnhancedConfirmResponseBody | ConfirmResponseErrorBody;
         status: number;
       }) => {
-        setIsFormDisabled(true);
         if (status !== 200) {
           notifyError(status);
         } else {
@@ -105,10 +104,12 @@ const AahMsaForm = ({
             notifyError(status);
             return;
           }
+
           onDataReceived(body);
 
           if (body?.length > 0) {
             onEligibilitySuccess();
+            setIsFormDisabled(true);
           } else {
             onEligibilityFailure();
           }

--- a/site/src/app/v2/test-eligibilite/components/step-two-forms/YoungCafForm.tsx
+++ b/site/src/app/v2/test-eligibilite/components/step-two-forms/YoungCafForm.tsx
@@ -108,7 +108,6 @@ const YoungCafForm = ({
         body: EnhancedConfirmResponseBody | ConfirmResponseErrorBody;
         status: number;
       }) => {
-        setIsFormDisabled(true);
         if (status !== 200) {
           notifyError(status);
         } else {
@@ -121,6 +120,7 @@ const YoungCafForm = ({
 
           if (body?.length > 0) {
             onEligibilitySuccess();
+            setIsFormDisabled(true);
           } else {
             onEligibilityFailure();
           }

--- a/site/src/app/v2/test-eligibilite/components/step-two-forms/YoungMsaForm.tsx
+++ b/site/src/app/v2/test-eligibilite/components/step-two-forms/YoungMsaForm.tsx
@@ -108,7 +108,6 @@ const YoungMsaForm = ({
         body: EnhancedConfirmResponseBody | ConfirmResponseErrorBody;
         status: number;
       }) => {
-        setIsFormDisabled(true);
         if (status !== 200) {
           notifyError(status);
         } else {
@@ -121,6 +120,7 @@ const YoungMsaForm = ({
 
           if (body?.length > 0) {
             onEligibilitySuccess();
+            setIsFormDisabled(true);
           } else {
             onEligibilityFailure();
           }


### PR DESCRIPTION
### Description
- When failure occurs at first step, enable fields in the first set of fields
- When failure occurs at second step, enable fields located in the second set of fields (not the first set of fields)

### Ticket
https://www.notion.so/369742af22d9486097d69a9cc301c1c1?v=6e22fafc1b4f4333a53a8906eb814126&p=98374cbb541b414db7c83ad76485abfb&pm=s