### PR TITLE
[Frontend] Breadcrumb - last part of breadcrumb (text) color updated

### DIFF
--- a/site/src/app/components/pass-sport-breadcrumb/styles.module.scss
+++ b/site/src/app/components/pass-sport-breadcrumb/styles.module.scss
@@ -17,5 +17,9 @@
   nav {
     max-width: $layout-max-width;
     margin: auto;
+
+    li:last-child > a{
+      color: var(--text-action-high-grey) !important;
+    }
   }
 }


### PR DESCRIPTION
### Description
⬆️ 


### Screenshot
<img width="326" alt="Screenshot 2024-06-18 at 09 18 30" src="https://github.com/betagouv/pass-sport/assets/1215376/c1be059c-7367-415e-8db2-d08768ba1431">


### Ticket
https://www.notion.so/369742af22d9486097d69a9cc301c1c1?v=6e22fafc1b4f4333a53a8906eb814126&p=8947198284c245c7ad0e6d8c17be78e8&pm=s