### PR TITLE
[Frontend] Itinerary implementation & various fixes

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -11,6 +11,7 @@
         "@codegouvfr/react-dsfr": "^1.9.8",
         "@sentry/nextjs": "^8.5.0",
         "@socialgouv/matomo-next": "^1.9.0",
+        "@uidotdev/usehooks": "^2.4.1",
         "classnames": "^2.5.1",
         "crisp-api": "^8.3.2",
         "leaflet": "^1.9.4",
@@ -3867,6 +3868,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@uidotdev/usehooks": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@uidotdev/usehooks/-/usehooks-2.4.1.tgz",
+      "integrity": "sha512-1I+RwWyS+kdv3Mv0Vmc+p0dPYH0DTRAo04HLyXReYBL9AeseDWUJyi4THuksBJcu9F0Pih69Ak150VDnqbVnXg==",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
       }
     },
     "node_modules/@ungap/structured-clone": {

--- a/site/package.json
+++ b/site/package.json
@@ -21,6 +21,7 @@
     "@codegouvfr/react-dsfr": "^1.9.8",
     "@sentry/nextjs": "^8.5.0",
     "@socialgouv/matomo-next": "^1.9.0",
+    "@uidotdev/usehooks": "^2.4.1",
     "classnames": "^2.5.1",
     "crisp-api": "^8.3.2",
     "leaflet": "^1.9.4",

--- a/site/src/app/v2/trouver-un-club/[club-name]/components/clubDetails/ClubDetails.tsx
+++ b/site/src/app/v2/trouver-un-club/[club-name]/components/clubDetails/ClubDetails.tsx
@@ -3,12 +3,15 @@
 import styles from '@/app/v2/trouver-un-club/[club-name]/style.module.scss';
 import { Tag } from '@codegouvfr/react-dsfr/Tag';
 import { formatPhoneNumber } from '@/app/v2/trouver-un-club/[club-name]/helpers';
-import MedicalCertificatePanel from '@/app/v2/trouver-un-club/[club-name]/components/medicalCertificatPanel/MedicalCertificatePanel';
-import { useMemo } from 'react';
+import MedicalCertificatePanel from '../medicalCertificatPanel/MedicalCertificatePanel';
+import { useCallback, useMemo } from 'react';
 import dynamic from 'next/dynamic';
 import { useGetClubs } from '@/app/hooks/use-get-clubs';
 import { DisabilityTag } from '../../../components/disability-tag/DisabilityTag';
 import cn from 'classnames';
+import Link from 'next/link';
+import { useGetMapUrl } from '../../hooks/use-get-map-url';
+import { push } from '@socialgouv/matomo-next';
 
 interface Props {
   clubName: string;
@@ -17,8 +20,11 @@ interface Props {
 
 function ClubDetails({ clubName, isProVersion = false }: Props) {
   const { club, error } = useGetClubs(clubName);
-
   const Map = useMemo(() => dynamic(() => import('../map/Map')), []);
+  const mapUrl = useGetMapUrl(club);
+  const onGoToItinerary = useCallback(() => {
+    push(['trackEvent', 'Check itinerary', 'Clicked', 'Itinerary on google maps']);
+  }, []);
 
   if (error) {
     return <p className={styles.error}>{error}</p>;
@@ -44,39 +50,61 @@ function ClubDetails({ clubName, isProVersion = false }: Props) {
 
             <DisabilityTag club={club} small />
           </div>
-          <div className={styles.contact}>
-            {(club.adresse || club.commune) && (
-              <p className="fr-text--xs fr-m-0">
-                <span
-                  className={`fr-pr-1w fr-icon-map-pin-2-line ${styles['icon-color']} fr-icon--sm`}
-                  aria-hidden="true"
-                ></span>
-                {club.adresse && club.adresse}
-                {club.adresse && club.commune && ', '}
-                {club.commune && club.commune}
-              </p>
-            )}
 
-            {club.telephone && (
-              <p className="fr-text--xs fr-m-0">
-                <span
-                  className={`fr-pr-1w fr-icon-phone-line ${styles['icon-color']} fr-icon--sm`}
-                  aria-hidden="true"
-                ></span>
-                {formatPhoneNumber(club.telephone)}
-              </p>
-            )}
+          <div className={styles['contact-wrapper']}>
+            <section className={styles.contact}>
+              {(club.adresse || club.commune) && (
+                <p className="fr-text--xs fr-m-0">
+                  <span
+                    className={`fr-pr-1w fr-icon-map-pin-2-line ${styles['icon-color']} fr-icon--sm`}
+                    aria-hidden="true"
+                  />
 
-            {club.courriel && (
-              <p className="fr-text--xs fr-m-0">
-                <span
-                  className={`fr-pr-1w fr-icon-mail-line ${styles['icon-color']} fr-icon--sm`}
-                  aria-hidden="true"
-                ></span>
-                {club.courriel}
-              </p>
+                  <span>
+                    {club.adresse && club.adresse}
+                    {club.adresse && club.commune && ', '}
+                    {club.commune && club.commune}
+                  </span>
+                </p>
+              )}
+
+              {club.telephone && (
+                <p className="fr-text--xs fr-m-0">
+                  <span
+                    className={`fr-pr-1w fr-icon-phone-line ${styles['icon-color']} fr-icon--sm`}
+                    aria-hidden="true"
+                  ></span>
+                  {formatPhoneNumber(club.telephone)}
+                </p>
+              )}
+
+              {club.courriel && (
+                <p className="fr-text--xs fr-m-0">
+                  <span
+                    className={`fr-pr-1w fr-icon-mail-line ${styles['icon-color']} fr-icon--sm`}
+                    aria-hidden="true"
+                  ></span>
+                  {club.courriel}
+                </p>
+              )}
+            </section>
+
+            {mapUrl && (
+              <div className={styles['contact-itinerary']}>
+                <Link
+                  href={mapUrl}
+                  target="_blank"
+                  title={
+                    "Ouverture d'une nouvelle fenêtre vers google maps contenant l'itinéraire vers le club"
+                  }
+                  onClick={onGoToItinerary}
+                >
+                  Voir l&apos;itinéraire
+                </Link>
+              </div>
             )}
           </div>
+
           <hr className={`fr-mt-3w fr-mb-0 fr-mx-0 ${styles.separator}`} />
 
           {Array.isArray(club.activites) && (

--- a/site/src/app/v2/trouver-un-club/[club-name]/components/medicalCertificatPanel/MedicalCertificatePanel.tsx
+++ b/site/src/app/v2/trouver-un-club/[club-name]/components/medicalCertificatPanel/MedicalCertificatePanel.tsx
@@ -12,10 +12,13 @@ const MedicalCertificatePanel = () => {
         border={false}
         desc={
           <>
-            <p className="fr-text--lg">
+            <span className="fr-text--lg">
               Ce simulateur vous indique si vous devez obtenir un certificat médical pour pratiquer
               une activité sportive (loisir ou compétition).
-            </p>
+            </span>
+
+            <br />
+            <br />
 
             <Link
               href="https://www.service-public.fr/simulateur/calcul/certificatMedical"

--- a/site/src/app/v2/trouver-un-club/[club-name]/hooks/use-get-map-url.ts
+++ b/site/src/app/v2/trouver-un-club/[club-name]/hooks/use-get-map-url.ts
@@ -1,0 +1,61 @@
+import { Club } from '../../../../../../types/Club';
+import { useGeolocation } from '@uidotdev/usehooks';
+
+// 'dir' for directions from origin to destination
+// 'search' for displaying the map with a specific place
+type MapMode = 'dir' | 'search';
+
+function useGetMapUrl(club: Club | null) {
+  const userLocation = useGeolocation();
+  const hasUserLocation = userLocation.latitude && userLocation.longitude;
+  const mapMode: MapMode = hasUserLocation ? 'dir' : 'search';
+
+  // source: https://developers.google.com/maps/documentation/urls/get-started
+  const baseUrl = new URL(`https://www.google.com/maps/${mapMode}/`);
+  const searchParams = new URLSearchParams({ api: '1' });
+
+  if (club === null) return null;
+
+  let clubLocation = getClubLocation(club);
+
+  if (mapMode === 'dir') {
+    if (clubLocation !== null) {
+      searchParams.append('origin', `${userLocation.latitude},${userLocation.longitude}`);
+      searchParams.append('destination', clubLocation);
+
+      baseUrl.search = searchParams.toString();
+
+      return baseUrl;
+    }
+
+    return null;
+  }
+
+  if (mapMode === 'search') {
+    if (clubLocation !== null) {
+      searchParams.append('query', clubLocation);
+      baseUrl.search = searchParams.toString();
+
+      return baseUrl;
+    }
+
+    return null;
+  }
+
+  return null;
+}
+
+function getClubLocation(club: Club) {
+  // Prioritize geo coordinates first, if not present, take full address
+  if (club.geoloc_finale?.lat && club.geoloc_finale?.lon) {
+    return `${club.geoloc_finale.lat},${club.geoloc_finale.lon}`;
+  }
+
+  if (club.adresse) {
+    return `${club.adresse} ${club.commune || ''} ${club.cplt_1 || ''}`.trim();
+  }
+
+  return null;
+}
+
+export { useGetMapUrl };

--- a/site/src/app/v2/trouver-un-club/[club-name]/style.module.scss
+++ b/site/src/app/v2/trouver-un-club/[club-name]/style.module.scss
@@ -21,6 +21,25 @@
     gap: 8px;
   }
 
+  .contact-wrapper {
+    display: flex;
+
+    @media screen and (max-width: $md) {
+      flex-direction: column;
+    }
+  }
+
+  .contact-itinerary {
+    text-align: right;
+    flex: 1;
+
+    @media screen and (max-width: $md) {
+      flex: initial;
+      text-align: left;
+      padding-top: 16px;
+    }
+  }
+
   .tags {
     display: flex;
     flex-direction: column;

--- a/site/types/Club.ts
+++ b/site/types/Club.ts
@@ -7,6 +7,7 @@ type YesNo = 'Oui' | 'Non';
 
 export interface Club {
   nom: string;
+  cplt_1: string | null;
   cp: string;
   activites: string[] | null;
   adresse: string | null;


### PR DESCRIPTION
### Description
- Go to itinerary implementation on club details page
- Matomo tracking on itinerary link clicks
- Fixed existing semantic HTML bug (paragraph cannot be descendant of paragraph error) in MedicalCertificatePanel

### Itinerary behaviour
If user gives permission to get its location, we use the directions in googlemaps, otherwise we just search for a specific place

If the club has the geocoordinates we take them, otherwise we take its address, if it has none of these, we don't display the itinerary URL

### Responsive
<img width="300" alt="Screenshot 2024-06-20 at 12 34 31" src="https://github.com/betagouv/pass-sport/assets/1215376/3bdd281b-a214-4ea6-b0d2-102c3d7f58e7">
<img width="972" alt="Screenshot 2024-06-20 at 12 34 28" src="https://github.com/betagouv/pass-sport/assets/1215376/21df9af9-6d8b-447f-a283-77e500648bb8">


### Notion ticket
https://www.notion.so/369742af22d9486097d69a9cc301c1c1?v=6e22fafc1b4f4333a53a8906eb814126&p=0e281b3961994df4880e362ae0c9bc96&pm=s 