### PR TITLE
[CI] CI fixes due to ubuntu-latest image runner migration 

### DIFF
--- a/.github/workflows/nginx-test.yml
+++ b/.github/workflows/nginx-test.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-
+      - name: Check Docker version
+        run: docker --version
       # - name: Build & test staging
       #   run: docker-compose run  --rm check-nginx-conf"
-      
       - name: Build & test prod
         run: | 
           cd .ci

--- a/.github/workflows/nginx-test.yml
+++ b/.github/workflows/nginx-test.yml
@@ -13,6 +13,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Check Docker version
         run: docker --version
+      - name: Check Docker Compose version
+        run: docker-compose --version
       # - name: Build & test staging
       #   run: docker-compose run  --rm check-nginx-conf"
       - name: Build & test prod

--- a/.github/workflows/nginx-test.yml
+++ b/.github/workflows/nginx-test.yml
@@ -14,10 +14,10 @@ jobs:
       - name: Check Docker version
         run: docker --version
       - name: Check Docker Compose version
-        run: docker-compose --version
+        run: docker compose --version
       # - name: Build & test staging
       #   run: docker-compose run  --rm check-nginx-conf"
       - name: Build & test prod
         run: | 
           cd .ci
-          docker-compose run  --rm check-nginx-conf
+          docker compose run  --rm check-nginx-conf

--- a/.github/workflows/nginx-test.yml
+++ b/.github/workflows/nginx-test.yml
@@ -11,10 +11,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Check Docker version
-        run: docker --version
-      - name: Check Docker Compose version
-        run: docker compose --version
       # - name: Build & test staging
       #   run: docker-compose run  --rm check-nginx-conf"
       - name: Build & test prod


### PR DESCRIPTION
### Description
docker-compose v1 has been deprecated [here](https://github.com/actions/runner-images/issues/9692)
The fix is to use the v2 command that is to say **docker compose**

### Ticket
- https://www.notion.so/369742af22d9486097d69a9cc301c1c1?v=6e22fafc1b4f4333a53a8906eb814126&p=0967d742104d47e08490b4554957f6ab&pm=s