### PR TITLE
[Frontend][Matomo] Safeguard hashtag matmom bugfix

### DIFF
--- a/site/src/app/Matomo.tsx
+++ b/site/src/app/Matomo.tsx
@@ -7,14 +7,16 @@ export default function Matomo() {
   const isInitialLoad = useRef(true);
 
   const transformQrCodeUrl = (): string => {
-    const { pathname } = window.location;
+    const { pathname, hash } = window.location;
 
     let updatedPathName = pathname;
-    let regex = /\/code\/scan\/.*/;
+    let regex = /\/code\/scan.*/;
+    const urlMatchRegex = regex.test(pathname);
 
-    if (regex.test(pathname)) {
+    if (urlMatchRegex) {
       updatedPathName = pathname.replace(regex, `/code/scan/24-xxxx-xxxx`);
     }
+
     return updatedPathName;
   };
 

--- a/site/src/app/Matomo.tsx
+++ b/site/src/app/Matomo.tsx
@@ -14,7 +14,7 @@ export default function Matomo() {
     const urlMatchRegex = regex.test(pathname);
 
     if (urlMatchRegex) {
-      updatedPathName = pathname.replace(regex, `/code/scan/24-xxxx-xxxx`);
+      updatedPathName = pathname.replace(regex, `/code/scan`);
     }
 
     return updatedPathName;

--- a/site/src/app/Matomo.tsx
+++ b/site/src/app/Matomo.tsx
@@ -7,7 +7,7 @@ export default function Matomo() {
   const isInitialLoad = useRef(true);
 
   const transformQrCodeUrl = (): string => {
-    const { pathname, hash } = window.location;
+    const { pathname } = window.location;
 
     let updatedPathName = pathname;
     let regex = /\/code\/scan.*/;


### PR DESCRIPTION
### Description
In the setCustomUrl callback, we handle the hashtag that appears on the QR page code recap. For some reason Matomo is sometimes pushing the URL with the hashtag even though this option has been disabled by the beta.gouv team

### Ticket
- https://www.notion.so/65db4ac9850e4b8c9cab4954ad154035?p=9a9e6bd033d2487c849b85773aeeb441&pm=c