### PR TITLE
chore: faq links pro & faq style update

### DIFF
--- a/site/src/app/v2/pro/ressources/page.tsx
+++ b/site/src/app/v2/pro/ressources/page.tsx
@@ -47,9 +47,15 @@ export default function ToutSavoirSurLePassSport() {
             </p>
 
             <p>
-              Aidez-nous à enrichir cette cartographie en nous faisant remonter l’information via
-              PassSport@sports.gouv.fr et partage ainsi votre action en direction des bénéficiaires
-              ou de leurs familles.
+              Aidez-nous à enrichir cette cartographie en nous faisant remonter l’information via{' '}
+              <Link
+                href="/v2/pro/une-question"
+                target="_blank"
+                aria-label="Ouvrir une nouvelle fenêtre vers la foire aux questions"
+              >
+                le formulaire en bas de la Foire aux questions
+              </Link>{' '}
+              et partagez ainsi votre action en direction des bénéficiaires ou de leurs familles.
             </p>
           </div>
 

--- a/site/src/app/v2/pro/tout-savoir-sur-le-pass-sport/page.tsx
+++ b/site/src/app/v2/pro/tout-savoir-sur-le-pass-sport/page.tsx
@@ -92,8 +92,14 @@ export default function ToutSavoirSurLePassSport() {
               </li>
               <li className="fr-mb-3w">
                 Si vous êtes bien une association agréée Sport ou JEP (agrément valide), contactez
-                l&apos;assistance passSport@sports.gouv.fr qui vous orientera vers l&apos;assistance
-                de proximité dans votre territoire.
+                l&apos;assistance via{' '}
+                <Link
+                  href="/v2/pro/une-question"
+                  target="_blank"
+                  aria-label="Ouvrir une nouvelle fenêtre vers la foire aux questions"
+                >
+                  le formulaire en bas de la Foire aux questions
+                </Link>
               </li>
               <li>
                 Pour toute question sur le dispositif, la FAQ sur ce portail devrait vous apporter

--- a/site/src/app/v2/une-question/components/ContentSection/ContentSection.tsx
+++ b/site/src/app/v2/une-question/components/ContentSection/ContentSection.tsx
@@ -123,7 +123,7 @@ export default function ContentSection({ categoriesWithArticles }: Props) {
           return (
             <li key={article.id} id={article.id} className="cursor--pointer">
               <div
-                className="fr-callout"
+                className="fr-callout fr-mb-0"
                 role="button"
                 tabIndex={0}
                 onKeyDown={(event) => {
@@ -136,7 +136,7 @@ export default function ContentSection({ categoriesWithArticles }: Props) {
                   onArticleSelect(article);
                 }}
               >
-                <span className="display--block fr-callout__title fr-h3">{article.title}</span>
+                <span className="display--block fr-callout__title fr-h6">{article.title}</span>
                 {selectedArticle !== null && (
                   <>
                     <div className={cn('fr-callout__text', styles['faq__callout-text'])}>


### PR DESCRIPTION
### Description
- Updated FAQ styling (reduced gaps between articles & reduced article's title size)
- Updated typo/links in pro pages to point to FAQ

### Tickets
- https://www.notion.so/FAQ-Reduire-espacement-entre-questions-et-reduire-taille-des-titres-des-articles-8f5e849ced644064a7310284b2a03174
- https://www.notion.so/Site-Pro-Supprimer-les-mentions-l-adresse-mail-passSport-sports-gouv-fr-rediriger-vers-le-mail-2684e4fbffd34c67b1a382b946421abb

### Screenshots
<img width="1340" alt="Screenshot 2024-08-28 at 11 21 42" src="https://github.com/user-attachments/assets/ce7ad9bb-e8b6-4fa2-b5c4-6fe6e9e96ab3">
<img width="1394" alt="Screenshot 2024-08-28 at 11 21 34" src="https://github.com/user-attachments/assets/1d082c76-b7a1-499c-a636-484e9954642f">
