### PR TITLE
[Frontend] FAQ Redesign

### DIFF
--- a/site/src/app/v2/pro/une-question/page.tsx
+++ b/site/src/app/v2/pro/une-question/page.tsx
@@ -26,7 +26,7 @@ export default async function Questions() {
       <main tabIndex={-1} id={SKIP_LINKS_ID.mainContent} role="main">
         <PageTitle
           title="Vous avez une question ?"
-          subtitle="Consultez notre FAQ la réponse à votre question s'y trouve peut-être."
+          subtitle="Consultez nos questions fréquentes, la réponse à votre question s’y trouve peut-être."
           classes={{
             container: styles['page-header'],
           }}

--- a/site/src/app/v2/une-question/components/ContentSection/ContentSection.tsx
+++ b/site/src/app/v2/une-question/components/ContentSection/ContentSection.tsx
@@ -2,13 +2,13 @@
 
 import { Article, CategoryWithArticles } from '../../../../../../types/Faq';
 import styles from './styles.module.scss';
-import React, { useCallback, useState } from 'react';
+import React from 'react';
 import cn from 'classnames';
 import Markdown from 'react-markdown';
 import remarkBreaks from 'remark-breaks';
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useSearchParams } from 'next/navigation';
 import { push } from '@socialgouv/matomo-next';
-import rootStyles from '@/app/utilities.module.scss';
+import Accordion from '@codegouvfr/react-dsfr/Accordion';
 
 interface Props {
   categoriesWithArticles: CategoryWithArticles[];
@@ -16,11 +16,8 @@ interface Props {
 
 export default function ContentSection({ categoriesWithArticles }: Props) {
   const searchParams = useSearchParams();
-  const pathname = usePathname();
-  const { replace } = useRouter();
   const articleId = searchParams?.get('articleId') || null;
   let articleFromUrl: Article | null = null;
-  let defaultCategory = categoriesWithArticles[0];
 
   // If there is an article id in the url
   // we need to set the selectedArticle and the selectedCategory associated to it
@@ -30,7 +27,6 @@ export default function ContentSection({ categoriesWithArticles }: Props) {
 
       if (articleFound) {
         articleFromUrl = articleFound;
-        defaultCategory = category;
 
         // break out of loop if found
         return true;
@@ -40,138 +36,44 @@ export default function ContentSection({ categoriesWithArticles }: Props) {
     });
   }
 
-  const [selectedCategory, setSelectedCategory] = useState<CategoryWithArticles>(defaultCategory);
-
-  const [selectedArticle, setSelectedArticle] = useState<
-    CategoryWithArticles['articles'][0] | null
-  >(articleFromUrl);
-
-  const onArticleSelect = useCallback(
-    (article: Article) => {
-      if (selectedArticle === null) {
-        setSelectedArticle(article);
-        replace(`${pathname}?articleId=${article.id}#${article.id}`);
-        push(['trackEvent', 'View FAQ', `Clicked`, `${article.title} (${article.id})`]);
-      }
-    },
-    [pathname, replace, selectedArticle],
-  );
-
-  const onCategorySelect = useCallback(
-    (category: CategoryWithArticles) => {
-      setSelectedCategory(category);
-      setSelectedArticle(null);
-      replace(`${pathname}`);
-      push(['trackEvent', 'View FAQ', `Clicked`, `${category.name} (${category.id})`]);
-    },
-    [pathname, replace],
-  );
-
   return (
-    <section className={styles['faq']}>
-      <div>
-        <nav
-          className={cn('fr-summary', 'fr-pt-0', styles['faq__summary'])}
-          role="navigation"
-          aria-labelledby="fr-summary-title"
-        >
-          {categoriesWithArticles.length > 0 && (
-            <p className="fr-summary__title fr-p-0 fr-pl-md-1w" id="fr-summary-title">
-              Categories
-            </p>
-          )}
+    <div className={styles['faq']}>
+      {categoriesWithArticles.map((category: CategoryWithArticles) => (
+        <section key={category.id} className="fr-mb-8w">
+          <h2
+            className={cn('fr-h3', 'fr-m-0', 'fr-px-4w', 'fr-pb-2w', styles['faq__article-title'])}
+          >
+            {category.name}
+          </h2>
 
-          <ul className={cn('fr-summary__list', 'fr-p-0', 'fr-pl-md-3w')}>
-            {categoriesWithArticles.map((category, index) => {
-              return (
-                <li
-                  key={category.id}
-                  className={cn('cursor--pointer', {
-                    [styles['faq__category--selected']]: selectedCategory?.id === category.id,
-                  })}
-                >
-                  <div
-                    role="button"
-                    tabIndex={0}
-                    onClick={() => {
-                      onCategorySelect(category);
-                    }}
-                    onKeyDown={(event) => {
-                      // Check if the key is Enter or Space
-                      if (event.key === 'Enter' || event.key === ' ') {
-                        onCategorySelect(category);
-                      }
-                    }}
-                  >
-                    {/* We need to do it this way otherwise the voice over is reading the numbering (if we use the css property list-style-type) */}
-                    <span aria-hidden="true" className="fr-text--bold">
-                      {index + 1}.{' '}
-                    </span>
-                    <span>{category.name}</span>
-                  </div>
-                </li>
-              );
-            })}
-          </ul>
-        </nav>
-      </div>
-
-      <ul className={cn('fr-ml-0', styles['faq__questions'], rootStyles['list--lean'])}>
-        {selectedCategory?.articles.map((article) => {
-          if (selectedArticle !== null && article.id !== selectedArticle.id) return null;
-
-          return (
-            <li key={article.id} id={article.id} className={cn('fr-pt-3w', 'cursor--pointer')}>
-              <div
-                className="fr-callout fr-mb-0"
-                role="button"
-                tabIndex={0}
-                onKeyDown={(event) => {
-                  // Check if the key is Enter or Space
-                  if (event.key === 'Enter' || event.key === ' ') {
-                    onArticleSelect(article);
-                  }
-                }}
-                onClick={() => {
-                  onArticleSelect(article);
-                }}
+          {category.articles.map((article) => (
+            <Accordion
+              key={article.id}
+              label={article.title}
+              defaultExpanded={articleFromUrl?.id === article.id}
+              onExpandedChange={() => {
+                push(['trackEvent', 'View FAQ', `Clicked`, `${article.title} (${article.id})`]);
+              }}
+            >
+              <article
+                id={article.id}
+                className={cn('fr-px-6w', 'fr-pt-2w', styles['faq__accordion-expanded-container'])}
               >
-                <span className="display--block fr-callout__title fr-h6">{article.title}</span>
-                {selectedArticle !== null && (
-                  <>
-                    <div className={cn('fr-callout__text', styles['faq__callout-text'])}>
-                      <Markdown remarkPlugins={[remarkBreaks]} className={styles['faq__markdown']}>
-                        {article.content}
-                      </Markdown>
-                    </div>
+                <Markdown remarkPlugins={[remarkBreaks]} className={styles['faq__markdown']}>
+                  {article.content}
+                </Markdown>
 
-                    <button
-                      aria-label="Retour à la foire aux questions"
-                      className="fr-btn fr-btn--secondary fr-icon-arrow-left-line fr-btn--icon-left"
-                      onClick={(e) => {
-                        // Stop propagation to prevent clicking
-                        // on the article itself thus setting the selectedArticle again instead of setting it to null
-                        e.stopPropagation();
-                        setSelectedArticle(null);
-                        replace(`${pathname}#header`);
-                      }}
-                    >
-                      Retour
-                    </button>
-
-                    <div
-                      className={cn(styles['faq__feedback-date'], 'fr-text--sm')}
-                      suppressHydrationWarning
-                    >
-                      Mis à jour le : {new Date(selectedArticle.updatedAt).toLocaleDateString()}
-                    </div>
-                  </>
-                )}
-              </div>
-            </li>
-          );
-        })}
-      </ul>
-    </section>
+                <footer
+                  className={cn(styles['faq__feedback-date'], 'fr-text--sm')}
+                  suppressHydrationWarning
+                >
+                  Mis à jour le : {new Date(article.updatedAt).toLocaleDateString()}
+                </footer>
+              </article>
+            </Accordion>
+          ))}
+        </section>
+      ))}
+    </div>
   );
 }

--- a/site/src/app/v2/une-question/components/ContentSection/styles.module.scss
+++ b/site/src/app/v2/une-question/components/ContentSection/styles.module.scss
@@ -5,35 +5,25 @@
   top: -100px;
   background-color: var(--color-white);
   display: flex;
-  flex-direction: column;
   max-width: $layout-max-width;
   margin: 24px 24px -80px;
   padding-top: 24px;
+  flex-direction: column;
+
+  &__article-title {
+    color: var(--text-action-high-blue-france);
+  }
+
+  &__accordion-expanded-container {
+    display: flex;
+    flex-direction:column;
+    gap: 40px;
+    background-color: #EEE;
+  }
 
   @media (min-width: $md) {
     top: -60px;
-    flex-direction: row;
-    justify-content: space-between;
-    padding: 24px;
     margin: 0 auto -64px;
-  }
-
-  &__summary {
-    background-color: var(--color-white);
-  }
-
-  &__questions {
-    width: 100%;
-
-    @media (min-width: $md) {
-      width: 792px;
-    }
-  }
-
-  &__category {
-    &--selected {
-      color: #000091;
-    }
   }
 
   &__markdown {
@@ -47,16 +37,6 @@
 
     img {
       max-width: 100%;
-    }
-  }
-
-  &__callout {
-    &-text {
-      position: relative;
-      display: flex;
-      align-items: center;
-      flex-direction: row;
-      gap: 2rem;
     }
   }
 

--- a/site/src/app/v2/une-question/page.tsx
+++ b/site/src/app/v2/une-question/page.tsx
@@ -27,7 +27,7 @@ export default async function Questions() {
       <main tabIndex={-1} id={SKIP_LINKS_ID.mainContent} role="main">
         <PageTitle
           title="Vous avez une question ?"
-          subtitle="Consultez notre FAQ la réponse à votre question s'y trouve peut-être."
+          subtitle="Consultez nos questions fréquentes, la réponse à votre question s’y trouve peut-être."
           classes={{
             container: styles['page-header'],
           }}


### PR DESCRIPTION
# Description
- The articleId query parameter can still be passed in and the matching accordion will be opened
  - Example: <base-url>/v2/une-question?articleId=51975e40-7140-464e-ac93-ec611adec704 
- Redesign of the FAQ to avoid multiple navigations

# Ticket
- https://www.notion.so/369742af22d9486097d69a9cc301c1c1?v=6e22fafc1b4f4333a53a8906eb814126&p=103d86210f7a80108ca9d146ef3c886e&pm=s

# Desktop screenshot
![image](https://github.com/user-attachments/assets/9f9c9c26-538a-4ef5-8dd2-3809b9b8ac95)

# Mobile screenshot
![image](https://github.com/user-attachments/assets/1f54e901-4124-4a69-a384-b63cc13c2b10)
