### PR TITLE
[Frontend] Homepage btn typo + qr copy code notif + club details <address>

### DIFF
--- a/site/src/app/v2/accueil/page.messages.tsx
+++ b/site/src/app/v2/accueil/page.messages.tsx
@@ -3,23 +3,13 @@ import { PresentationTileProps } from './components/PresentationTile';
 export const presentationTiles: PresentationTileProps[] = [
   {
     id: 1,
-    title: (
-      <>
-        <span className="display--block">Découvrir</span>
-        <span className="display--block">le pass Sport</span>
-      </>
-    ),
+    title: <>Découvrir le pass Sport</>,
     badgeLabel: 'le pass sport',
     link: '/v2/tout-savoir-sur-le-pass-sport#découvrir',
   },
   {
     id: 2,
-    title: (
-      <>
-        <span className="display--block">Qui peut</span>
-        <span className="display--block">en bénéficier ?</span>
-      </>
-    ),
+    title: <>Qui peut en bénéficier ?</>,
     badgeLabel: 'le pass sport',
     link: '/v2/tout-savoir-sur-le-pass-sport#pour-qui',
   },

--- a/site/src/app/v2/code/scan/components/QrCodeCard/QrCodeCard.tsx
+++ b/site/src/app/v2/code/scan/components/QrCodeCard/QrCodeCard.tsx
@@ -6,7 +6,8 @@ import styles from './styles.module.scss';
 import Button from '@codegouvfr/react-dsfr/Button';
 import { push } from '@socialgouv/matomo-next';
 import { useCopyToClipboard } from '@uidotdev/usehooks';
-import { useCallback } from 'react';
+import { useCallback, useRef, useState } from 'react';
+import { Alert } from '@codegouvfr/react-dsfr/Alert';
 
 interface Props {
   data: {
@@ -21,6 +22,8 @@ interface Props {
 
 const QrCodeCard = ({ data, qrCodeValue }: Props) => {
   const { firstname, lastname, gender, code, birthDate } = data;
+  const notifRef = useRef<HTMLDivElement | null>(null);
+  const [isNotificationDisplayed, setIsNotificationDisplayed] = useState(false);
 
   const formatBirthDate = (rawDate: string | undefined, gender: string | undefined) => {
     if (!rawDate) {
@@ -45,6 +48,9 @@ const QrCodeCard = ({ data, qrCodeValue }: Props) => {
 
   const onCopyCallback = useCallback(() => {
     push(['trackEvent', 'Copy Code', 'Clicked', 'QR Recap page']);
+
+    setIsNotificationDisplayed(true);
+    notifRef.current?.focus();
 
     return copyToClipboard(data.code);
   }, [copyToClipboard, data.code]);
@@ -79,6 +85,18 @@ const QrCodeCard = ({ data, qrCodeValue }: Props) => {
           >
             Copier le code
           </Button>
+
+          <Alert
+            className="fr-mt-2w"
+            ref={notifRef}
+            severity="success"
+            title="Code copié"
+            description=""
+            closable
+            small
+            isClosed={!isNotificationDisplayed}
+            onClose={() => setIsNotificationDisplayed(false)}
+          />
         </div>
       </div>
 

--- a/site/src/app/v2/trouver-un-club/[club-name]/components/clubDetails/ClubDetails.tsx
+++ b/site/src/app/v2/trouver-un-club/[club-name]/components/clubDetails/ClubDetails.tsx
@@ -43,46 +43,45 @@ function ClubDetails({ clubName, isProVersion = false }: Props) {
 
           <div className={styles['contact-wrapper']}>
             <section className={styles.contact}>
-              <ul className={rootStyles['list--lean']}>
-                <li className="fr-text--xs fr-m-0">
-                  <span
-                    className={`fr-pr-1w fr-icon-map-pin-2-line ${styles['icon-color']} fr-icon--sm`}
-                    aria-hidden="true"
-                  />
-
+              <address className={cn(rootStyles['list--lean'], 'fr-text--xs')}>
+                {club.adresse || club.commune ? (
                   <span>
-                    {club.adresse || club.commune ? (
-                      <>
-                        {club.adresse && club.adresse}
-                        {club.adresse && club.commune && ', '}
-                        {club.commune && club.commune}
-                      </>
-                    ) : (
-                      <>Adresse non disponible</>
-                    )}
+                    <span
+                      className={`fr-pr-1w fr-icon-map-pin-2-line ${styles['icon-color']} fr-icon--sm`}
+                      aria-hidden="true"
+                    />
+                    <span>
+                      {club.adresse && club.adresse}
+                      {club.adresse && club.commune && ', '}
+                      {club.commune && club.commune}
+                    </span>
                   </span>
-                </li>
+                ) : (
+                  <span>Adresse non disponible</span>
+                )}
 
                 {club.telephone && (
-                  <li className="fr-text--xs fr-m-0">
+                  <span>
+                    <br />
                     <span
                       className={`fr-pr-1w fr-icon-phone-line ${styles['icon-color']} fr-icon--sm`}
                       aria-hidden="true"
-                    ></span>
-                    {formatPhoneNumber(club.telephone)}
-                  </li>
+                    />
+                    <span>{formatPhoneNumber(club.telephone)}</span>
+                  </span>
                 )}
 
                 {club.courriel && (
-                  <li className="fr-text--xs fr-m-0">
+                  <span>
+                    <br />
                     <span
                       className={`fr-pr-1w fr-icon-mail-line ${styles['icon-color']} fr-icon--sm`}
                       aria-hidden="true"
-                    ></span>
-                    {club.courriel}
-                  </li>
+                    />
+                    <span>{club.courriel}</span>
+                  </span>
                 )}
-              </ul>
+              </address>
             </section>
 
             {mapUrl && (


### PR DESCRIPTION
### Description
- Homepage: One liner for text (Couldn't find any way to solve it, adding spaces doesn't work)
- QR recap page: When clicking on the copy button, an alert is now displayed and is closeable
- Club details page, use address HTML element

### Tickets
- https://www.notion.so/Audit-avec-tickets-notion-526ecd6d84764c0c84844c2e41071fe2?p=3cafd73b31324e7ea0a4ceaa33ca5669&pm=s
- https://www.notion.so/Audit-avec-tickets-notion-526ecd6d84764c0c84844c2e41071fe2?p=8b45a6401726480797554b91229df52d&pm=s
- https://www.notion.so/Audit-avec-tickets-notion-526ecd6d84764c0c84844c2e41071fe2?p=3bb6c1be5b7b481e956f13e35a7a95bf&pm=s

### Screenshots
![Screenshot 2024-09-18 at 16 22 49](https://github.com/user-attachments/assets/59f8fb04-4da2-4b93-be5f-e3a8de84f2a9)
![Screenshot 2024-09-18 at 16 22 39](https://github.com/user-attachments/assets/20153c3d-c268-410d-96f1-32bbb402e06f)
![Screenshot 2024-09-18 at 16 33 10](https://github.com/user-attachments/assets/ef74ff2c-26f1-4e7b-8ceb-fd0f5f49cb8e)
