### PR TITLE
[Frontend] Budget page implementation

### DIFF
--- a/site/src/app/components/pass-sport-breadcrumb/PassSportBreadcrumbStandard.tsx
+++ b/site/src/app/components/pass-sport-breadcrumb/PassSportBreadcrumbStandard.tsx
@@ -17,6 +17,7 @@ export const NAVIGATION_ITEM_MAP: { [key: string]: string } = {
   '/v2/code/scan': 'Mon pass Sport',
   '/v2/plan-du-site': 'Plan du site',
   '/v2/accessibilite': 'Accessibilité',
+  '/v2/budget': 'Budget',
   '/v2/reglement-du-jeu-concours-numero-pass-sport-decathlon':
     'jeu-concours pass Sport - Décathlon',
 };

--- a/site/src/app/components/pass-sport-footer/PassSportFooter.tsx
+++ b/site/src/app/components/pass-sport-footer/PassSportFooter.tsx
@@ -207,6 +207,12 @@ export default function PassSportFooter() {
       },
     },
     {
+      text: 'Budget',
+      linkProps: {
+        href: '/v2/budget',
+      },
+    },
+    {
       text: 'Gestion des cookies',
       linkProps: {
         href: '#',

--- a/site/src/app/v2/budget/page.tsx
+++ b/site/src/app/v2/budget/page.tsx
@@ -92,7 +92,9 @@ function Page() {
                         <td className="fr-col-6 fr-col-md-4">483 538 €</td>
                       </tr>
                       <tr>
-                        <td className="fr-col-6 fr-col-md-8">Communication et envois</td>
+                        <td className="fr-col-6 fr-col-md-8">
+                          Communication & Campagnes d'email/sms
+                        </td>
                         <td className="fr-col-6 fr-col-md-4">2 010 948 €</td>
                       </tr>
                       <tr>

--- a/site/src/app/v2/budget/page.tsx
+++ b/site/src/app/v2/budget/page.tsx
@@ -93,7 +93,7 @@ function Page() {
                       </tr>
                       <tr>
                         <td className="fr-col-6 fr-col-md-8">
-                          Communication & Campagnes d'email/sms
+                          Communication & Campagnes d&apos;email/sms
                         </td>
                         <td className="fr-col-6 fr-col-md-4">2 010 948 €</td>
                       </tr>

--- a/site/src/app/v2/budget/page.tsx
+++ b/site/src/app/v2/budget/page.tsx
@@ -66,7 +66,7 @@ function Page() {
         </section>
 
         <section className="fr-mb-6w">
-          <div className="fr-table  fr-col-12 fr-table--bordered">
+          <div className="fr-table  fr-col-12">
             <div className="fr-table__wrapper">
               <div className="fr-table__container">
                 <div className="fr-table__content">
@@ -75,7 +75,7 @@ function Page() {
                     <thead className="fr-col-6">
                       <tr>
                         <th>Intitulé</th>
-                        <th>Total</th>
+                        <th>Somme</th>
                       </tr>
                     </thead>
                     <tbody>
@@ -98,7 +98,9 @@ function Page() {
                       <tr>
                         <td className="fr-col-6 fr-col-md-8">
                           Subvention{' '}
-                          <abbr title="Le Comité national olympique sportif français">CNOSF</abbr>
+                          <abbr title="Comité national olympique et sportif français (CNOSF)">
+                            CNOSF
+                          </abbr>
                         </td>
                         <td className="fr-col-6 fr-col-md-4">250 000 €</td>
                       </tr>

--- a/site/src/app/v2/budget/page.tsx
+++ b/site/src/app/v2/budget/page.tsx
@@ -1,0 +1,126 @@
+'use server';
+
+import { Metadata } from 'next';
+import styles from './styles.module.scss';
+import { SKIP_LINKS_ID } from '@/app/constants/skip-links';
+import PageTitle from '@/components/PageTitle/PageTitle';
+import Link from 'next/link';
+
+export async function generateMetadata(): Promise<Metadata> {
+  return {
+    title: 'Budget pass Sport',
+  };
+}
+
+function Page() {
+  return (
+    <main className={styles['container']} tabIndex={-1} id={SKIP_LINKS_ID.mainContent} role="main">
+      <PageTitle
+        title="Budget"
+        subtitle={
+          <p>
+            Le site pass Sport 2024 est un service public numérique, c’est pourquoi nous sommes
+            transparents sur les ressources allouées et la manière dont elles sont employées.
+          </p>
+        }
+        classes={{
+          container: styles['page-header'],
+        }}
+      />
+
+      <div className={styles.wrapper}>
+        <section className="fr-mb-6w">
+          <h2 className="fr-mb-2w">Principes</h2>
+          <p>
+            Nous suivons le{' '}
+            <Link href="https://beta.gouv.fr/manifeste" target="_blank">
+              manifeste beta.gouv
+            </Link>{' '}
+            dont nous rappelons les principes ici :
+          </p>
+          <ul>
+            <li>
+              Les besoins des utilisateurs sont prioritaires sur les besoins de l’administration
+            </li>
+            <li>Le mode de gestion de l’équipe repose sur la confiance</li>
+            <li>L&apos;équipe adopte une approche itérative et d’amélioration en continu</li>
+          </ul>
+        </section>
+
+        <section className="fr-mb-6w">
+          <h2 className="fr-mb-2w">Fonctionnement</h2>
+          <p>
+            L&apos;équipe est portée par un intrapreneur qui est responsable du service numérique
+            développé.
+          </p>
+          <p>
+            Son rôle est multiple : déploiement, gestion des produits, référent auprès de son
+            administration (budget, compte rendus d&apos;avancement).
+          </p>
+          <p>
+            L&apos;ensemble de l&apos;équipe et le descriptif du produit est décrit sur la{' '}
+            <Link href="https://beta.gouv.fr/startups/pass-sport.html" target="_blank">
+              fiche du produit beta.gouv.fr.
+            </Link>
+          </p>
+        </section>
+
+        <section className="fr-mb-6w">
+          <div className="fr-table  fr-col-12 fr-table--bordered">
+            <div className="fr-table__wrapper">
+              <div className="fr-table__container">
+                <div className="fr-table__content">
+                  <table className="fr-cell--multiline">
+                    <caption>Dépenses 2024</caption>
+                    <thead className="fr-col-6">
+                      <tr>
+                        <th>Intitulé</th>
+                        <th>Total</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr>
+                        <td className="fr-col-6 fr-col-md-8">
+                          Fonctionnement Direction des Sports
+                        </td>
+                        <td className="fr-col-6 fr-col-md-4">984 000 €</td>
+                      </tr>
+                      <tr>
+                        <td className="fr-col-6 fr-col-md-8">
+                          Fonctionnement Équipe produit (product owner, développeurs, designer)
+                        </td>
+                        <td className="fr-col-6 fr-col-md-4">483 538 €</td>
+                      </tr>
+                      <tr>
+                        <td className="fr-col-6 fr-col-md-8">Communication et envois</td>
+                        <td className="fr-col-6 fr-col-md-4">2 010 948 €</td>
+                      </tr>
+                      <tr>
+                        <td className="fr-col-6 fr-col-md-8">
+                          Subvention{' '}
+                          <abbr title="Le Comité national olympique sportif français">CNOSF</abbr>
+                        </td>
+                        <td className="fr-col-6 fr-col-md-4">250 000 €</td>
+                      </tr>
+                      <tr>
+                        <td className="fr-col-6 fr-col-md-8">Assistance usagers</td>
+                        <td className="fr-col-6 fr-col-md-4">257 990 €</td>
+                      </tr>
+
+                      <tr className="fr-text--bold">
+                        <td className="fr-col-6 fr-col-md-8">Coût total de fonctionnement</td>
+                        <td className="fr-col-6 fr-col-md-4">3 986 476 €</td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}
+
+export default Page;

--- a/site/src/app/v2/budget/styles.module.scss
+++ b/site/src/app/v2/budget/styles.module.scss
@@ -1,0 +1,24 @@
+@import '../../sassVariables.module';
+
+.wrapper {
+  max-width: $max-width;
+  margin: auto;
+  margin-top: 50px;
+  margin-bottom: 80px;
+  padding: 0 2rem;
+
+  @media screen and (max-width: $lg) {
+    padding: 0 1rem;
+  }
+
+  &__text--center {
+    text-align: center;
+  }
+}
+
+// Raise the specificity by adding twice the classname
+.page-header.page-header {
+  height: auto;
+  padding-bottom: 2rem;
+}
+

--- a/site/src/app/v2/plan-du-site/page.tsx
+++ b/site/src/app/v2/plan-du-site/page.tsx
@@ -34,6 +34,9 @@ export default function PlanDuSite() {
               <Link href="/v2/une-question">Une question ?</Link>
             </li>
             <li>
+              <Link href="/v2/budget">Budget</Link>
+            </li>
+            <li>
               <Link
                 href="https://lecompteasso.associations.gouv.fr/carto/dashboard"
                 target="_blank"

--- a/site/src/app/v2/pro/plan-du-site/page.tsx
+++ b/site/src/app/v2/pro/plan-du-site/page.tsx
@@ -37,6 +37,9 @@ export default function PlanDuSite() {
               <Link href="/v2/pro/une-question">Une question ?</Link>
             </li>
             <li>
+              <Link href="/v2/budget">Budget</Link>
+            </li>
+            <li>
               <Link
                 href="https://lecompteasso.associations.gouv.fr/carto/dashboard"
                 target="_blank"


### PR DESCRIPTION
### Description
- Budget page implementation + updated routing
- Added Budget link to footer
- Updated "Plan du site" pages to include Budget link (pro,user versions)

### Ticket
- https://www.notion.so/369742af22d9486097d69a9cc301c1c1?v=6e22fafc1b4f4333a53a8906eb814126&p=15fd86210f7a809292f2d35704dfa7ff&pm=s

### Screenshots
![Screenshot 2024-12-17 at 15 32 59](https://github.com/user-attachments/assets/a1d0514f-b341-4707-898d-0c3e43b829e0)
![Screenshot 2024-12-17 at 15 33 05](https://github.com/user-attachments/assets/bed39d67-7ef3-4653-92c1-9b982f301fe1)
