### PR TITLE
[Frontend] Eligiblity test - clubs count, eligibility test banner fixes

### DIFF
--- a/site/src/app/v2/test-eligibilite-base/components/aeehStep/AeehStep.tsx
+++ b/site/src/app/v2/test-eligibilite-base/components/aeehStep/AeehStep.tsx
@@ -82,7 +82,7 @@ const AeehStep = ({ ageRange }: Props) => {
         >
           <p className={cn('fr-text--lg', rootStyles['text--medium'], rootStyles['text--black'])}>
             Il vous permettra de déduire {PASS_SPORT_AMOUNT} euros sur l&apos;inscription prise
-            entre le 1er septembre et le 31 décembre 2025, parmi plus de 59 000 clubs, associations
+            entre le 1er septembre et le 31 décembre 2025, parmi plus de 85 000 clubs, associations
             sportives et salles de sport partenaires.
           </p>
         </VerdictPanel>

--- a/site/src/app/v2/test-eligibilite-base/components/ageStep2/AgeStep2.tsx
+++ b/site/src/app/v2/test-eligibilite-base/components/ageStep2/AgeStep2.tsx
@@ -125,7 +125,7 @@ const AgeStep2 = ({ ageRange, isForMySelf = false }: AgeStep2Props) => {
         >
           <p className={cn('fr-text--lg', rootStyles['text--medium'], rootStyles['text--black'])}>
             Il vous permettra de déduire {PASS_SPORT_AMOUNT} euros sur l&apos;inscription prise
-            entre le 1er septembre et le 31 décembre 2025, parmi plus de 59 000 clubs, associations
+            entre le 1er septembre et le 31 décembre 2025, parmi plus de 85 000 clubs, associations
             sportives et salles de sport partenaires.
           </p>
         </VerdictPanel>

--- a/site/src/app/v2/test-eligibilite-base/components/allowancesStep/AllowancesStep.tsx
+++ b/site/src/app/v2/test-eligibilite-base/components/allowancesStep/AllowancesStep.tsx
@@ -42,7 +42,7 @@ const AllowancesStep = () => {
       >
         <p className={cn('fr-text--lg', rootStyles['text--medium'], rootStyles['text--black'])}>
           Il vous permettra de déduire {PASS_SPORT_AMOUNT} euros sur l&apos;inscription prise entre
-          le 1er septembre et le 31 décembre 2025, parmi plus de 59 000 clubs, associations
+          le 1er septembre et le 31 décembre 2025, parmi plus de 85 000 clubs, associations
           sportives et salles de sport partenaires.
         </p>
       </VerdictPanel>

--- a/site/src/app/v2/trouver-un-club/[club-name]/page.tsx
+++ b/site/src/app/v2/trouver-un-club/[club-name]/page.tsx
@@ -23,7 +23,7 @@ const ClubPage = ({ params }: { params: { 'club-name': string } }) => {
         <ClubDetails clubName={clubName} />
       </main>
 
-      <EligibilityTestBanner />
+      {/*<EligibilityTestBanner />*/}
       <SocialMediaPanel />
     </>
   );

--- a/site/src/app/v2/trouver-un-club/components/club-count/ClubCount.tsx
+++ b/site/src/app/v2/trouver-un-club/components/club-count/ClubCount.tsx
@@ -7,8 +7,8 @@ interface Props {
 
 const ClubCount: React.FC<Props> = ({ totalClubCount }) => {
   const buildContent = () => {
-    if (totalClubCount > 80000) {
-      return 'Parmi plus de 80 000 clubs référencés';
+    if (totalClubCount > 85000) {
+      return 'Parmi plus de 85 000 clubs référencés';
     }
 
     return (
@@ -16,7 +16,7 @@ const ClubCount: React.FC<Props> = ({ totalClubCount }) => {
         <span>
           {totalClubCount} {totalClubCount === 1 ? 'club' : 'clubs'} près de chez vous
         </span>{' '}
-        sur 80 000 clubs référencés
+        sur 85 000 clubs référencés
       </>
     );
   };

--- a/site/src/app/v2/trouver-un-club/components/club-list-view/more-clubs-button/MoreClubsButton.tsx
+++ b/site/src/app/v2/trouver-un-club/components/club-list-view/more-clubs-button/MoreClubsButton.tsx
@@ -2,6 +2,7 @@ import Button from '@codegouvfr/react-dsfr/Button';
 import { SportGouvJSONRecordsResponse } from 'types/Club';
 import styles from './styles.module.scss';
 import cn from 'classnames';
+import { useIsProVersion } from '@/app/hooks/use-is-pro-version';
 
 interface Props {
   onClick: () => void;
@@ -9,13 +10,14 @@ interface Props {
 }
 const MoreClubsButton: React.FC<Props> = ({ clubs, onClick }) => {
   const isLastPage = clubs.total_count === clubs.results.length;
+  const isProVersion = useIsProVersion();
 
   if (isLastPage) {
     return null;
   }
 
   return (
-    <div className={cn('fr-mt-9w', styles['more-clubs-wrapper'])}>
+    <div className={cn('fr-mt-9w', isProVersion ? 'fr-mb-4w' : '', styles['more-clubs-wrapper'])}>
       <Button
         priority="primary"
         size="large"

--- a/site/src/app/v2/trouver-un-club/page.tsx
+++ b/site/src/app/v2/trouver-un-club/page.tsx
@@ -34,7 +34,7 @@ const TrouverUnClub = async () => {
         </Suspense>
       </main>
 
-      <EligibilityTestBanner />
+      {/*<EligibilityTestBanner />*/}
       <SocialMediaPanel />
     </>
   );


### PR DESCRIPTION
### Description
- When finishing the eligibility test, the club count is wrong, should be 85 000 instead of 59 000
- Find a club page, 80 000 should be 85 000
- Eligibility test banner removed from find a club page + club details page on user version