### PR TITLE
[Frontend] Disable AEEH contact form modal on jeunes et parents & updated simulator 

### DIFF
--- a/site/src/app/components/simplified-eligibility-test/SimplifiedEligibilityTest.tsx
+++ b/site/src/app/components/simplified-eligibility-test/SimplifiedEligibilityTest.tsx
@@ -328,13 +328,23 @@ export default function SimplifiedEligibilityTest({
           {displayAeehLink && (
             <p className="fr-mb-0 fr-mt-3w text-align--center">
               <Link
-                href={`/v2/jeunes-et-parents?${JEUNES_PARENTS_PAGE_AEEH_PARAMS.aeehModalOpened}=1#${SKIP_LINKS_ID.aeehContent}`}
-                className="fr-link"
-                onClick={onAeehLinkClick}
+                href="/v2/test-eligibilite"
+                className="fr-btn fr-btn--secondary"
+                onClick={onCodeObtentionLinkClick}
               >
-                Contactez-nous pour demander votre pass Sport
+                Demander mon pass Sport
               </Link>
             </p>
+            // todo: Enable later
+            // <p className="fr-mb-0 fr-mt-3w text-align--center">
+            //   <Link
+            //     href={`/v2/jeunes-et-parents?${JEUNES_PARENTS_PAGE_AEEH_PARAMS.aeehModalOpened}=1#${SKIP_LINKS_ID.aeehContent}`}
+            //     className="fr-link"
+            //     onClick={onAeehLinkClick}
+            //   >
+            //     Contactez-nous pour demander votre pass Sport
+            //   </Link>
+            // </p>
           )}
 
           {displayEligibilityLink && (

--- a/site/src/app/v2/jeunes-et-parents/page.tsx
+++ b/site/src/app/v2/jeunes-et-parents/page.tsx
@@ -194,26 +194,26 @@ export default function Page() {
                 étudiants boursiers.
               </li>
             </ol>
-            <section className="fr-my-4w" id={SKIP_LINKS_ID.aeehContent}>
-              <KnowMore
-                variant="yellow"
-                knowMore={{
-                  title: `Exception pour les bénéficiaires de l'AEEH entre 6 et 13 ans`,
-                  description: CODES_OBTAINABLE
-                    ? 'Demandez votre pass Sport directement à partir de ce formulaire'
-                    : `Demandez votre pass Sport directement sur notre site à partir du 1er septembre.`,
-                }}
-              >
-                {CODES_OBTAINABLE && <ContactAeehSection />}
-              </KnowMore>
-              {/* todo: confirm with Julianne */}
-              {/*<p>*/}
-              {/*  <span className="fr-text--bold">*/}
-              {/*    Exception pour les bénéficiaires de l&apos;AEEH*/}
-              {/*  </span>{' '}*/}
-              {/*  : demandez votre pass Sport directement sur notre site à partir du 1er septembre.*/}
-              {/*</p>*/}
-            </section>
+            {/*<section className="fr-my-4w" id={SKIP_LINKS_ID.aeehContent}>*/}
+            {/*  <KnowMore*/}
+            {/*    variant="yellow"*/}
+            {/*    knowMore={{*/}
+            {/*      title: `Exception pour les bénéficiaires de l'AEEH entre 6 et 13 ans`,*/}
+            {/*      description: CODES_OBTAINABLE*/}
+            {/*        ? 'Demandez votre pass Sport directement à partir de ce formulaire'*/}
+            {/*        : `Demandez votre pass Sport directement sur notre site à partir du 1er septembre.`,*/}
+            {/*    }}*/}
+            {/*  >*/}
+            {/*    {CODES_OBTAINABLE && <ContactAeehSection />}*/}
+            {/*  </KnowMore>*/}
+            {/*  /!* todo: confirm with Julianne *!/*/}
+            {/*  /!*<p>*!/*/}
+            {/*  /!*  <span className="fr-text--bold">*!/*/}
+            {/*  /!*    Exception pour les bénéficiaires de l&apos;AEEH*!/*/}
+            {/*  /!*  </span>{' '}*!/*/}
+            {/*  /!*  : demandez votre pass Sport directement sur notre site à partir du 1er septembre.*!/*/}
+            {/*  /!*</p>*!/*/}
+            {/*</section>*/}
             Si, après cette date vous n&apos;avez pas reçu votre pass Sport :
             <ol className="fr-ml-2w" start={1}>
               <li>Vérifiez dans vos spams ou indésirables.</li>


### PR DESCRIPTION
### Description
- Removed AEEH Contact form modal on page "Jeunes et parents"
- Updated simulator case for AEEH, it is no longer a link but a button that redirects to /v2/test-eliibilite