### PR TITLE
[Backend] Link mobility report demarche simplifiees extraction

### DIFF
--- a/data/2025/aeeh/lm-reports-output-to-ds.ipynb
+++ b/data/2025/aeeh/lm-reports-output-to-ds.ipynb
@@ -1,0 +1,91 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "34c6766e0e41e164",
+   "metadata": {},
+   "source": [
+    "# Process\n",
+    "- Import the Link Mobility report file that contains the codes, emails, error message\n",
+    "- Take benefs that weren't delivered\n",
+    "- Match those benefs with data from production\n",
+    "- Output a CSV file with the folder id, email, code and link to Demarches Simplifiees"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5f326369a72bea66",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import pandas as pd\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "load_dotenv()\n",
+    "wave_report_filepath = os.getenv('WAVE_REPORT_FILEPATH')\n",
+    "production_benefs_with_folders_id_filepath = os.getenv('PRODUCTION_BENEF_WITH_FOLDERS_ID')\n",
+    "\n",
+    "df = pd.read_csv(wave_report_filepath,on_bad_lines='skip', sep=';', dtype=str, engine=\"c\", keep_default_na=False, encoding='utf-8')\n",
+    "df.rename(columns={'CODE': 'id_psp', 'EMAIL': 'email'}, inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bd1d27f2f1663cbb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df['NM_ERROR_NAME'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "83b84aa7bf5f1928",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mask_not_delivered = (df['NM_ERROR_NAME'] == 'Non D�livr�') | (df['NM_ERROR_NAME'] == 'Dest. Inconnu') | (df['NM_ERROR_NAME'] == 'Bo�te non dispo.') | (df['NM_ERROR_NAME'] == 'Message Refus�')\n",
+    "df_codes_not_delivered = df[mask_not_delivered]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9357d4e297d3a6d8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_wave_2 = pd.read_csv(production_benefs_with_folders_id_filepath, on_bad_lines='skip', sep=';', dtype=str, engine=\"c\", keep_default_na=False, encoding=\"utf-8\")\n",
+    "\n",
+    "df_dossiers_not_delivered = pd.merge(df_wave_2, df_codes_not_delivered, how='inner', on='id_psp', suffixes=('', '_not_delivered'))\n",
+    "df_dossiers_not_delivered['folder_link'] = f'https://www.demarches-simplifiees.fr/procedures/126472/a-suivre/dossiers/' + df_dossiers_not_delivered['dossier_id']\n",
+    "df_dossiers_not_delivered[['id_psp', 'dossier_id', 'email', 'folder_link']].to_csv('./folders-not-delivered.csv', sep=';', encoding='utf-8', index=False)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
# Description
Process is the following
- Import the Link Mobility report file that contains the codes, emails, error message
- Take benefs that weren't delivered
- Match those benefs with data from production
- Output a CSV file with the folder id, email, code and link to Demarches Simplifiees

# Ticket
https://www.notion.so/Implementation-d-un-script-pour-extraire-les-b-n-ficiaires-non-delivr-s-des-vagues-AEEH-27dd86210f7a80728ea0cf59a9d44ddf