### PR TITLE
fix: contact json parse bugfix

### DIFF
--- a/site/pages/api/contact.ts
+++ b/site/pages/api/contact.ts
@@ -48,12 +48,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }
   }
 
-  const jsonBody = JSON.parse(req.body);
-
   let body: ContactRequestBody;
 
   try {
-    body = contactFormSchema.parse(jsonBody);
+    body = contactFormSchema.parse(req.body);
   } catch (e) {
     return res.status(400).send((e as Error).message);
   }


### PR DESCRIPTION
# Description
- Because of the content-type now added for the WAF, it is no longer necessary to parse the used to be string req.body